### PR TITLE
fix bazel; usage comment

### DIFF
--- a/builder/build_feedstock.py
+++ b/builder/build_feedstock.py
@@ -23,9 +23,9 @@ recipe(s) found within that package's build tree, or with an alternative
 recipe specified on the command line.
 
 Usage:
-   $ build_package.py [ arguments ]
+   $ build_feedstock.py [ arguments ]
 For usage description of arguments, this script supports use of --help:
-   $ build_package.py --help
+   $ build_feedstock.py --help
 
 *******************************************************************************
 """

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -7,8 +7,6 @@ autoconf:
 automake:
   - 1.16
 bazel:
-  - 2.0.*
-bazel3:
   - 3.*
 boost:
   - 1.67.0


### PR DESCRIPTION
Fix for bazel - left over from internal where we had multiple bazel builds.

Also fix a old usage comment in `build_feedstock.py`