### PR TITLE
Add functionality to build_env for building in docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ git clone https://github.com/open-ce/open-ce.git
 ./open-ce/builder/build_env.py open-ce/envs/opence-env.yaml
 ```
 
+#### Building within a docker container
+Passing the `--docker_build` argument to the `build_env.py` script will create a docker image and perform the actual build inside of a container based on that image. This will provide a "clean" environment for the builds and make builds more system independent. It is recommended to build with this option as opposed to running on a bare metal machine. For more information on the `--docker_build` option, please see `doc/README.build_env.md`.
+
 ### Building a Single Feedstock
 The `build_feedstock.py` script can be used to build a single feedstock (which could produce one or more conda packages). The output from running `build_feedstock.py` will be a local conda channel (by default called `condabuild`). For more details on `build_feedstock.py`, please see `doc/README.build_feedstock.md`.
 

--- a/builder/build_env.py
+++ b/builder/build_env.py
@@ -41,6 +41,7 @@ import conda_build.api
 from conda_build.config import get_or_merge_config
 
 import build_feedstock
+import docker_build
 import utils
 
 DEFAULT_BUILD_TYPES = "cpu,cuda"
@@ -93,6 +94,14 @@ repositories will be downloaded to the current working directory.""")
         type=str,
         default=None,
         help='Git tag to be checked out for all of the packages in an environment.')
+
+    parser.add_argument(
+        '--docker_build',
+        action='store_true',
+        help="""Perform a build within a docker container.
+NOTE: When the --docker_build flag is used, all arguments with paths should be relative to the
+directory containing open-ce. Only files within the open-ce directory and local_files will
+be visible at build time.""")
 
     return parser
 
@@ -304,6 +313,10 @@ def build_env(arg_strings=None): #pylint: disable=too-many-locals,too-many-branc
     '''
     parser = make_parser()
     args = parser.parse_args(arg_strings)
+
+    if args.docker_build:
+        return docker_build.build_with_docker(args.output_folder, sys.argv)
+
     result = 0
 
     python_build_args = []

--- a/builder/docker_build.py
+++ b/builder/docker_build.py
@@ -1,0 +1,69 @@
+"""
+*****************************************************************
+Licensed Materials - Property of IBM
+(C) Copyright IBM Corp. 2020. All Rights Reserved.
+US Government Users Restricted Rights - Use, duplication or
+disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+*****************************************************************
+"""
+import os
+
+OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images/builder")
+LOCAL_FILES_PATH = os.path.join(os.path.dirname(OPEN_CE_PATH), "local_files")
+HOME_PATH = "/home/builder"
+
+REPO_NAME = "open-ce"
+
+def build_image():
+    """
+    Build a docker image from the Dockerfile in BUILD_IMAGE_PATH.
+    Returns a result code and the name of the new image.
+    """
+    image_name = REPO_NAME + ":open-ce-builder-" + str(os.getuid())
+    build_cmd = "docker build "
+    build_cmd += "-f " + os.path.join(BUILD_IMAGE_PATH, "Dockerfile") + " "
+    build_cmd += "-t " + image_name + " "
+    build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
+    build_cmd += "--build-arg GROUP_ID=" + str(os.getgid()) + " "
+    build_cmd += "."
+
+    result = os.system(build_cmd)
+
+    return result, image_name
+
+def build_in_container(image_name, output_folder, arg_strings):
+    """
+    Run a build inside of a container using the provided image_name.
+    """
+    docker_cmd = "docker run --rm "
+
+    # Add output folder
+    local_output_folder = os.path.join(os.getcwd(), output_folder)
+    if not os.path.isdir(local_output_folder):
+        os.mkdir(local_output_folder)
+    docker_cmd += "-v " + local_output_folder + ":" + os.path.join(HOME_PATH, output_folder) + ":rw "
+
+    # Add open-ce directory
+    docker_cmd += "-v " + OPEN_CE_PATH + ":" + HOME_PATH + "/open-ce:ro "
+
+    # Add local_files directory (if it exists)
+    if os.path.isdir(os.path.join(os.getcwd(), "local_files")):
+        docker_cmd += "-v " + os.getcwd() + "/local_files:" + HOME_PATH + "/local_files:ro "
+
+    docker_cmd += image_name + " "
+    docker_cmd += "bash -c 'cd " + HOME_PATH + "; " + ' '.join(arg_strings)  + "'"
+
+    result = os.system(docker_cmd)
+
+    return result
+
+def build_with_docker(output_folder, arg_strings):
+    """
+    Create a build image and run a build inside of container based on that image.
+    """
+    result, image_name = build_image()
+    arg_strings.remove("--docker_build")
+    result = build_in_container(image_name, output_folder, arg_strings)
+
+    return result

--- a/builder/docker_build.py
+++ b/builder/docker_build.py
@@ -7,7 +7,7 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 *****************************************************************
 """
 import os
-from datetime import datetime
+import datetime
 
 OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images/builder")
@@ -17,13 +17,15 @@ HOME_PATH = "/home/builder"
 REPO_NAME = "open-ce"
 IMAGE_NAME = "open-ce-builder"
 
+DOCKER_TOOL = "docker"
+
 def build_image():
     """
     Build a docker image from the Dockerfile in BUILD_IMAGE_PATH.
     Returns a result code and the name of the new image.
     """
     image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + str(os.getuid())
-    build_cmd = "docker build "
+    build_cmd = DOCKER_TOOL + " build "
     build_cmd += "-f " + os.path.join(BUILD_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "
     build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
@@ -34,15 +36,12 @@ def build_image():
 
     return result, image_name
 
-def build_in_container(image_name, output_folder, arg_strings):
+def _create_container(container_name, image_name, output_folder):
     """
-    Run a build inside of a container using the provided image_name.
+    Create a docker container
     """
-    time_stamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    container_name = IMAGE_NAME + "-" + time_stamp
-
     # Create the container
-    docker_cmd = "docker create -i --rm --name " + container_name + " "
+    docker_cmd = DOCKER_TOOL + " create -i --rm --name " + container_name + " "
 
     # Add output folder
     local_output_folder = os.path.join(os.getcwd(), output_folder)
@@ -52,46 +51,70 @@ def build_in_container(image_name, output_folder, arg_strings):
 
     docker_cmd += image_name + " bash"
     result = os.system(docker_cmd)
+
+    return result
+
+def _copy_to_container(src, dest, container_name):
+    result = os.system(DOCKER_TOOL + " cp " + src + " " + container_name + ":" + dest)
+    return result
+
+def _start_container(container_name):
+    result = os.system(DOCKER_TOOL + " start " + container_name)
+    return result
+
+def _execute_in_container(container_name, command):
+    docker_cmd = DOCKER_TOOL + " exec " + container_name + " "
+    # Change to home directory"
+    docker_cmd += "bash -c 'cd " + HOME_PATH + "; " + command + "'"
+
+    result = os.system(docker_cmd)
+    return result
+
+def _stop_container(container_name):
+    result = os.system(DOCKER_TOOL + " stop " + container_name)
+    return result
+
+def build_in_container(image_name, output_folder, arg_strings):
+    """
+    Run a build inside of a container using the provided image_name.
+    """
+    time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    container_name = IMAGE_NAME + "-" + time_stamp
+
+    result = _create_container(container_name, image_name, output_folder)
     if result:
         print("Error creating docker container: " + container_name)
-        return 1
+        return result
 
     # Add the open-ce directory
-    result = os.system("docker cp " + OPEN_CE_PATH + " " + container_name + ":" + HOME_PATH)
+    result = _copy_to_container(OPEN_CE_PATH, HOME_PATH, container_name)
     if result:
         print("Error copying open-ce directory into container")
         return 1
 
     # Add local_files directory (if it exists)
     if os.path.isdir(os.path.join(os.getcwd(), "local_files")):
-        result = os.system("docker cp " + os.path.join(os.getcwd(), "local_files") + " " + container_name + ":" + HOME_PATH)
+        result = _copy_to_container(os.path.join(os.getcwd(), "local_files"), HOME_PATH, container_name)
         if result:
             print("Error copying local_files into container")
             return 1
 
-    result = os.system("docker start " + container_name)
+    result = _start_container(container_name)
     if result:
         print("Error starting container " + container_name)
         return 1
 
-    docker_cmd = "docker exec " + container_name + " "
-    # Change to home directory"
-    docker_cmd += "bash -c 'cd " + HOME_PATH + "; "
-
     # Execute build command
-    docker_cmd += "python " + os.path.join(HOME_PATH, "open-ce", "builder", os.path.basename(arg_strings[0])) + " "
-    docker_cmd += ' '.join(arg_strings[1:])  + "'"
-    result = os.system(docker_cmd)
+    cmd = ("python " + os.path.join(HOME_PATH, "open-ce", "builder", os.path.basename(arg_strings[0])) + " " +
+              ' '.join(arg_strings[1:]))
+    result = _execute_in_container(container_name, cmd)
+
+    _stop_container(container_name)
+
     if result:
         print("Error executing build in container")
-        return 1
 
-    result = os.system("docker stop " + container_name)
-    if result:
-        print("Error stopping container " + container_name)
-        return result
-
-    return 0
+    return result
 
 def build_with_docker(output_folder, arg_strings):
     """
@@ -102,7 +125,9 @@ def build_with_docker(output_folder, arg_strings):
         print("Failure building image: " + image_name)
         return result
 
-    arg_strings.remove("--docker_build")
+    if "--docker_build" in arg_strings:
+        arg_strings.remove("--docker_build")
+
     result = build_in_container(image_name, output_folder, arg_strings)
 
     return result

--- a/builder/docker_build.py
+++ b/builder/docker_build.py
@@ -11,7 +11,7 @@ import datetime
 
 OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images/builder")
-LOCAL_FILES_PATH = os.path.join(os.path.dirname(OPEN_CE_PATH), "local_files")
+LOCAL_FILES_PATH = os.path.join(os.path.join(os.getcwd(), "local_files")
 HOME_PATH = "/home/builder"
 
 REPO_NAME = "open-ce"
@@ -93,8 +93,8 @@ def build_in_container(image_name, output_folder, arg_strings):
         return 1
 
     # Add local_files directory (if it exists)
-    if os.path.isdir(os.path.join(os.getcwd(), "local_files")):
-        result = _copy_to_container(os.path.join(os.getcwd(), "local_files"), HOME_PATH, container_name)
+    if os.path.isdir(LOCAL_FILES_PATH):
+        result = _copy_to_container(LOCAL_FILES_PATH, HOME_PATH, container_name)
         if result:
             print("Error copying local_files into container")
             return 1

--- a/builder/docker_build.py
+++ b/builder/docker_build.py
@@ -11,7 +11,7 @@ import datetime
 
 OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images/builder")
-LOCAL_FILES_PATH = os.path.join(os.path.join(os.getcwd(), "local_files")
+LOCAL_FILES_PATH = os.path.join(os.path.join(os.getcwd(), "local_files"))
 HOME_PATH = "/home/builder"
 
 REPO_NAME = "open-ce"

--- a/builder/docker_build.py
+++ b/builder/docker_build.py
@@ -64,7 +64,7 @@ def _start_container(container_name):
 
 def _execute_in_container(container_name, command):
     docker_cmd = DOCKER_TOOL + " exec " + container_name + " "
-    # Change to home directory"
+    # Change to home directory
     docker_cmd += "bash -c 'cd " + HOME_PATH + "; " + command + "'"
 
     result = os.system(docker_cmd)

--- a/ci_common_scripts/imageconfig
+++ b/ci_common_scripts/imageconfig
@@ -6,7 +6,7 @@ BASE_LAYER="base"
 NO_CACHE="--no-cache"
 
 REPO_NAME="open-ce"
-ROOT_FOLDER="open-ce/ci_common_scripts/base"
+ROOT_FOLDER="open-ce/images/builder/"
 
 DOCKER_DIR=${CUR_DIR}
 DISTRO_VERSION="7.7"

--- a/doc/README.build_env.md
+++ b/doc/README.build_env.md
@@ -32,7 +32,18 @@ You do not need to execute `build_feedstock.py` directly yourself, although
 you may do so if you wish to perform an individual build of your own
 for any given Open-CE feedstock repository.
 
-Command usage for `build_env.py`:
+## Docker build
+The `--docker_build` option will build an image and run the build command
+inside of a container based on the new image.
+
+As part of this process, it will copy a local_files directory that is in the
+current working directory into the container, if the directory exists.
+
+The paths to the `env_config_file`s and `--conda_build_config` must point to
+files within the `open-ce` directory and be relative to the directory
+containing the `open-ce` directory.
+
+##Command usage for `build_env.py`
 
 ```shell
 ==============================================================================
@@ -43,6 +54,7 @@ usage: build_env.py [-h] [--repository_folder REPOSITORY_FOLDER]
                     [--build_types BUILD_TYPES] [--git_location GIT_LOCATION]
                     [--git_tag_for_env GIT_TAG_FOR_ENV]
                     [--channels CHANNELS_LIST]
+                    [--docker_build]
                     env_config_file [env_config_file ...]
 
 Build conda environment as part of Open-CE
@@ -78,6 +90,12 @@ optional arguments:
   --git_tag_for_env GIT_TAG_FOR_ENV
                         Git tag to be checked out for all of the packages in
                         an environment. (default: None)
+  --docker_build        Perform a build within a docker container. NOTE: When
+                        the --docker_build flag is used, all arguments with
+                        paths should be relative to the directory containing
+                        open-ce. Only files within the open-ce directory and
+                        local_files will be visible at build time.
+                        (default: False)
   --channels CHANNELS_LIST
                         Extra conda channel to be used. (default: [])
 ==============================================================================

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -3,11 +3,10 @@ FROM registry.access.redhat.com/ubi7/ubi
 ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
 ENV PATH=$CONDA_HOME/bin:$PATH
 
-
 ENV CICD_GROUP=cicd
-ENV CICD_ID=1500
+ARG GROUP_ID=1500
 ENV BUILD_USER=builder
-ENV BUILD_ID=1084
+ARG BUILD_ID=1084
 ENV IBM_POWERAI_LICENSE_ACCEPT=yes
 
 RUN export ARCH="$(uname -m)" && \
@@ -17,9 +16,9 @@ RUN export ARCH="$(uname -m)" && \
     git \
     patch && \
     # Create CICD Group
-    groupadd --gid ${CICD_ID} ${CICD_GROUP} && \
+    groupadd --gid ${GROUP_ID} ${CICD_GROUP} && \
     # Adduser Builder
-    useradd -b /home --create-home --gid ${CICD_GROUP} --groups wheel \
+    useradd -b /home --create-home --gid ${GROUP_ID} --groups wheel \
     --uid ${BUILD_ID} --comment "User for Building" ${BUILD_USER} && \
     echo "${BUILD_USER}    ALL=NOPASSWD: ALL" > /etc/sudoers.d/user-${BUILD_USER} && \
     curl -o /tmp/anaconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-${ARCH}.sh && \

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -236,3 +236,13 @@ def test_env_validate(mocker, capsys):
     assert build_env.build_env([env_file]) == 1
     captured = capsys.readouterr()
     assert "chnnels is not a valid key in the environment file." in captured.err
+
+def test_build_env_docker_build(mocker):
+    '''
+    Test that passing the --docker_build argument calls docker_build.build_with_docker
+    '''
+    arg_strings = ["--docker_build", "my-env.yaml"]
+
+    mocker.patch('docker_build.build_with_docker', return_value=0)
+
+    assert build_env.build_env(arg_strings) == 0

--- a/tests/docker_build_test.py
+++ b/tests/docker_build_test.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import pathlib
+from datetime import date
 test_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.append(os.path.join(test_dir, '..', 'builder'))
 
@@ -27,3 +28,144 @@ def test_build_image(mocker):
     result, image_name = docker_build.build_image()
     assert result == 0
     assert image_name == intended_image_name
+
+def test_create_container(mocker):
+    '''
+    Simple test for _create_container
+    '''
+    mocker.patch('os.getcwd', return_value='/my_dir')
+    mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('os.mkdir')
+
+    container_name = "my_container"
+    image_name = "my_image"
+    output_folder = "condabuild"
+
+    mocker.patch(
+        'os.system',
+        return_value=0,
+        side_effect=(lambda x: helpers.validate_cli(x, expect=[docker_build.DOCKER_TOOL + " create",
+                                                               "--name " + container_name,
+                                                               "-v /my_dir/" + output_folder,
+                                                               image_name])))
+
+    assert docker_build._create_container(container_name, image_name, output_folder) == 0
+
+def test_copy_to_container(mocker):
+    '''
+    Simple test for _copy_to_container
+    '''
+    src = "my_src"
+    dest = "my_dest"
+    container = "my_container"
+
+    mocker.patch(
+        'os.system',
+        return_value=0,
+        side_effect=(lambda x: helpers.validate_cli(x, expect=[docker_build.DOCKER_TOOL + " cp",
+                                                               container + ":"])))
+
+    assert docker_build._copy_to_container(src, dest, container) == 0
+
+def test_execute_in_container(mocker):
+    '''
+    Simple test for _execute_in_container
+    '''
+    container = "my_container"
+    command = "my_script.py arg1 arg2"
+
+    mocker.patch(
+        'os.system',
+        return_value=0,
+        side_effect=(lambda x: helpers.validate_cli(x, expect=[docker_build.DOCKER_TOOL + " exec " + container,
+                                                               "my_script.py arg1 arg2"])))
+
+    assert docker_build._execute_in_container(container, command) == 0
+ 
+def test_build_in_container(mocker):
+    '''
+    Simple test for build_in_container
+    '''
+    mocker.patch('os.getcwd', return_value='/my_dir')
+    mocker.patch('os.path.isdir', return_value=[False, True])
+    mocker.patch('os.mkdir')
+
+    mocker.patch('os.system', return_value=0)
+
+    assert docker_build.build_in_container("my_image", "condabuild", ["path/to/my_script.py", "arg1", "arg2"]) == 0
+
+def test_docker_build_failures(mocker, capsys):
+    '''
+    Test situations where the docker commands fail
+    '''
+    image = "my_image"
+    output_folder = "condabuild"
+    cmd = ["path/to/my_script.py", "arg1", "arg2"]
+
+    mocker.patch('os.path.isdir', return_value = True)
+
+    # Failed create
+    mocker.patch('docker_build._create_container', return_value=1)
+
+    assert docker_build.build_in_container(image, output_folder, cmd) == 1
+    captured = capsys.readouterr()
+    assert "Error creating" in captured.out
+
+    # Failed first copy
+    mocker.patch('docker_build._create_container', return_value=0)
+    mocker.patch('docker_build._copy_to_container', side_effect=[1,1])
+
+    assert docker_build.build_in_container(image, output_folder, cmd) == 1
+    captured = capsys.readouterr()
+    assert "Error copying open-ce directory" in captured.out
+
+    # Failed second copy
+    mocker.patch('docker_build._copy_to_container', side_effect=[0,1])
+
+    assert docker_build.build_in_container(image, output_folder, cmd) == 1
+    captured = capsys.readouterr()
+    assert "Error copying local_files" in captured.out
+
+    # Failed start
+    mocker.patch('docker_build._copy_to_container', return_value=0)
+    mocker.patch('docker_build._start_container', return_value=1)
+
+    assert docker_build.build_in_container(image, output_folder, cmd) == 1
+    captured = capsys.readouterr()
+    assert "Error starting" in captured.out
+
+    # Failed execute
+    mocker.patch('docker_build._start_container', return_value=0)
+    mocker.patch('docker_build._execute_in_container', return_value=1)
+
+    assert docker_build.build_in_container(image, output_folder, cmd) == 1
+    captured = capsys.readouterr()
+    assert "Error executing" in captured.out
+
+def test_build_with_docker(mocker):
+    '''
+    Simple test for build_with_docker
+    '''
+    image_name = "my_image"
+    output_folder = "condabuild"
+    arg_strings = ["path/to/my_script.py", "--docker_build", "my-env.yaml"]
+
+    mocker.patch('docker_build.build_image', return_value=(0, image_name))
+
+    mocker.patch('docker_build.build_in_container', return_value=0)
+
+    assert docker_build.build_with_docker(output_folder, arg_strings) == 0
+
+def test_build_with_docker_failures(mocker, capsys):
+    '''
+    Failure cases for build_with_docker
+    '''
+    image_name = "my_image"
+    output_folder = "condabuild"
+    arg_strings = ["path/to/my_script.py", "--docker_build", "my-env.yaml"]
+
+    mocker.patch('docker_build.build_image', return_value=(1, image_name))
+
+    assert docker_build.build_with_docker(output_folder, arg_strings) == 1
+    captured = capsys.readouterr()
+    assert "Failure building image" in captured.out

--- a/tests/docker_build_test.py
+++ b/tests/docker_build_test.py
@@ -1,3 +1,14 @@
+# *****************************************************************
+#
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# *****************************************************************
+
 import os
 import sys
 import pathlib

--- a/tests/docker_build_test.py
+++ b/tests/docker_build_test.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pathlib
+test_dir = pathlib.Path(__file__).parent.absolute()
+sys.path.append(os.path.join(test_dir, '..', 'builder'))
+
+import pytest
+import helpers
+
+import docker_build
+
+def test_build_image(mocker):
+    '''
+    Simple test for build_image
+    '''
+    mocker.patch('os.getuid', return_value=1234)
+    mocker.patch('os.getgid', return_value=5678)
+
+    intended_image_name = docker_build.REPO_NAME + ":" + docker_build.IMAGE_NAME + "-1234"
+
+    mocker.patch(
+        'os.system',
+        return_value=0,
+        side_effect=(lambda x: helpers.validate_cli(x, expect=["docker build",
+                                                               "-t " + intended_image_name])))
+
+    result, image_name = docker_build.build_image()
+    assert result == 0
+    assert image_name == intended_image_name


### PR DESCRIPTION
This PR will add the `--docker_build` option to `build_env.py`. This option will tell the build_env script to build a docker image and run the actual build_env job within a container based on that image. The purpose of this feature is to allow the user to easily build packages within a clean environment.