### PR TITLE
add hub to tensorflow env

### DIFF
--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -18,4 +18,5 @@ packages:
   - feedstock : tensorflow-estimator
   - feedstock : tensorboard
   - feedstock : tensorboard-plugin-wit
+  - feedstock : tensorflow-hub
   - feedstock : protobuf          #['3.8' in python]


### PR DESCRIPTION
Add Hub to the Tensorflow env.

Requires: https://github.com/open-ce/tensorflow-hub-feedstock/pull/1