### PR TITLE
add CUDA_HOME to cuda images

### DIFF
--- a/images/builder-cuda-ppc64le/Dockerfile
+++ b/images/builder-cuda-ppc64le/Dockerfile
@@ -2,6 +2,7 @@ FROM nvidia/cuda-ppc64le:10.2-devel-ubi7
 
 ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
 ENV PATH=$CONDA_HOME/bin:$PATH
+ENV CUDA_HOME=/usr/local/cuda
 
 
 ENV CICD_GROUP=cicd

--- a/images/builder-cuda-x86_64/Dockerfile
+++ b/images/builder-cuda-x86_64/Dockerfile
@@ -2,6 +2,7 @@ FROM nvidia/cuda:10.2-devel-ubi7
 
 ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
 ENV PATH=$CONDA_HOME/bin:$PATH
+ENV CUDA_HOME=/usr/local/cuda
 
 
 ENV CICD_GROUP=cicd


### PR DESCRIPTION
The `nvcc` package needs CUDA_HOME set to build.
Add CUDA_HOME env variable to the CUDA builder images.