### PR TITLE
Docker copy output folder

### DIFF
--- a/open-ce/docker_build.py
+++ b/open-ce/docker_build.py
@@ -29,8 +29,8 @@ def build_image():
     build_cmd = DOCKER_TOOL + " build "
     build_cmd += "-f " + os.path.join(BUILD_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "
-#    build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
-#    build_cmd += "--build-arg GROUP_ID=" + str(os.getgid()) + " "
+    build_cmd += "--build-arg BUILD_ID=" + str(os.getuid()) + " "
+    build_cmd += "--build-arg GROUP_ID=" + str(os.getgid()) + " "
     build_cmd += "."
 
     result = os.system(build_cmd)

--- a/open-ce/docker_build.py
+++ b/open-ce/docker_build.py
@@ -8,7 +8,6 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 """
 import os
 import datetime
-import shutil
 
 OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 BUILD_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images/builder")


### PR DESCRIPTION
If the output folder doesn't exist before a docker_build, don't create it ahead of time. Instead, copy the output_folder from the container after the build has completed.