### PR TITLE
Enable feedstock value in an env config file to contain a url

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -25,6 +25,7 @@ import build_feedstock
 from utils import OpenCEError
 
 DEFAULT_GIT_LOCATION = "https://github.com/open-ce"
+SUPPORTED_GIT_PROTOCOLS = ["https:", "http:", "git@"]
 
 class BuildCommand():
     """
@@ -252,9 +253,9 @@ class BuildTree():
                 if _make_hash(package) in packages_seen:
                     continue
 
-                # If the feedstock value starts with https: or git@, treat it as a url. Otheriwse
+                # If the feedstock value starts with any of the SUPPORTED_GIT_PROTOCOLS, treat it as a url. Otherwise
                 # combine with git_location and append "-feedstock.git"
-                if package['feedstock'].startswith("https:") or package['feedstock'].startswith("git@"):
+                if any(package['feedstock'].startswith(protocol) for protocol in SUPPORTED_GIT_PROTOCOLS):
                     git_url = package['feedstock']
                     if not git_url.endswith(".git"):
                         git_url += ".git"

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -89,7 +89,7 @@ def test_clone_repo(mocker):
                                                                "/test/my_repo"]))
     )
 
-    assert mock_build_tree._clone_repo("/test/my_repo", None, "master") == 0
+    assert mock_build_tree._clone_repo(git_location + "/my_repo.git", "/test/my_repo", None, "master") == 0
 
 def test_clone_repo_failure(mocker, capsys):
     '''
@@ -104,7 +104,7 @@ def test_clone_repo_failure(mocker, capsys):
         side_effect=(lambda x: helpers.validate_cli(x, expect=["git clone"], retval=1))
     )
 
-    assert mock_build_tree._clone_repo("/test/my_repo", None, "master") == 1
+    assert mock_build_tree._clone_repo("https://bad_url", "/test/my_repo", None, "master") == 1
     captured = capsys.readouterr()
     assert "Unable to clone repository" in captured.out
 

--- a/tests/test-env1.yaml
+++ b/tests/test-env1.yaml
@@ -13,8 +13,8 @@ channels:
     - https://public.dhe.ibm.com/ibmdl/export/pub/software/server/ibm-ai/conda/
 packages:
     - feedstock : package11
-    - feedstock : package12
-    - feedstock : package13
-    - feedstock : package14
+    - feedstock : https://myhost.com/myorg/package12-feedstock
+    - feedstock : http://myhost.com/myorg/package13-feedstock.git
+    - feedstock : git@myhost/myorg/package14-feedstock.git
     - feedstock : package15
     - feedstock : package16


### PR DESCRIPTION
This PR will allow for the `feedstock` value in an environment config file to contain a url, instead of just providing a name of the feedstock. This will enable feedstocks to be hosted in locations besides `git_location`.

An environment file can now have values like this:

```
packages:
  - feedstock : https://github.com/open-ce/srsly-feedstock.git
  - feedstock : https://github.com/open-ce/thinc-feedstock
  - feedstock : git@github.com:open-ce/spacy-feedstock.git
  - feedstock : transformers
```