### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior, include the script and all arguments.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Execution Logs**
+If applicable, add logs to help explain your problem.
+
+**System (please complete the following information):**
+ - OS: [e.g. RHEL, Windows]
+ - Architecture [e.g. Power, x86]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[REQUEST]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feedstock-request.md
+++ b/.github/ISSUE_TEMPLATE/feedstock-request.md
@@ -1,0 +1,17 @@
+---
+name: Feedstock Request
+about: Suggest a new package you think should be part of this project.
+title: "[FEEDSTOCK REQUEST]"
+labels: Feedstock Request
+assignees: ''
+
+---
+
+**Describe the package you'd like added**
+A clear and concise description of what you want to happen.
+
+**Describe how this package fits in with the project**
+A clear and concise description of why this package should be added to the project.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: I have a quesiton about Open-CE
+title: "[QUESTION]"
+labels: question
+assignees: ''
+
+---
+
+**Your question:**
+Please ask your question here.


### PR DESCRIPTION
With the addition of the contribution guidelines, I was looking at the recommended [community standards](https://github.com/open-ce/open-ce/community). Those standards include having issue templates.
