### PR TITLE
Add the __len__ function to BuildTree

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -335,3 +335,6 @@ class BuildTree():
 
     def __getitem__(self, key):
         return self.build_commands[key]
+
+    def __len__(self):
+        return len(self.build_commands)

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -140,3 +140,11 @@ def test_get_dependency_names(mocker):
 
     assert output == expected_output
 
+def test_build_tree_len(mocker):
+    '''
+    Tests that the __len__ function works for BuildTree
+    '''
+    mock_build_tree = TestBuildTree([], "3.6", "cpu")
+    mock_build_tree.build_commands = sample_build_commands
+
+    assert len(mock_build_tree) == 3


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Adds the ability to call `len()` on a `BuildTree` object by implementing the __len__ method in BuildTree, as requested by @ketank-new.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
