### PR TITLE
Remove . from BuildCommand's name

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -81,7 +81,7 @@ class BuildCommand():
         """
         result = self.recipe
         if self.python:
-            result +=  "-py" + self.python
+            result +=  "-py" + self.python.replace(".","")
         if self.build_type:
             result +=  "-" + self.build_type
         return result

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -136,7 +136,7 @@ def test_get_dependency_names(mocker):
     for build_command in mock_build_tree:
         output += ' '.join([mock_build_tree[dep].name() for dep in build_command.build_command_dependencies]) + "\n"
 
-    expected_output = "\nrecipe2-py2.6-cpu\nrecipe2-py2.6-cpu recipe3\n"
+    expected_output = "\nrecipe2-py26-cpu\nrecipe2-py26-cpu recipe3\n"
 
     assert output == expected_output
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Removes the `.` from a BuildCommand's name. This is needed to work better with other tools that won't allow `.` in a name.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
