### PR TITLE
Improve build numbers check.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Open-CE Specific Ignores
+condabuild/
+
 # Byte-compiled / optimized / DLL files
 *__pycache__/
 *.py[cod]

--- a/tests/feedstock_tests/check_build_numbers.py
+++ b/tests/feedstock_tests/check_build_numbers.py
@@ -97,6 +97,6 @@ if __name__ == '__main__':
     try:
         main()
         print("BUILD NUMBER SUCCESS")
-    except Exception as exc:
+    except Exception as exc: # pylint: disable=broad-except
         print("BUILD NUMBER ERROR: ", exc)
         sys.exit(1)

--- a/tests/feedstock_tests/check_build_numbers.py
+++ b/tests/feedstock_tests/check_build_numbers.py
@@ -30,7 +30,7 @@ def make_parser():
                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     return parser
 
-def feedstock_pr(arg_strings=None):
+def main(arg_strings=None):
     '''
     Entry function.
     '''
@@ -52,36 +52,51 @@ def feedstock_pr(arg_strings=None):
     config.verbose = False
 
     utils.run_and_log("git checkout {}".format(default_branch))
-    master_build_numbers = set()
+    master_build_numbers = dict()
     for recipe in build_config_data["recipes"]:
         metas = conda_build.api.render(recipe['path'],
                                     config=config,
                                     variants=variants[0],
                                     bypass_env_check=True,
                                     finalize=False)
-        master_build_numbers.update([(meta.meta['package']['name'],
-                                      meta.meta['package']['version'],
-                                      meta.meta['build']['number']) for meta,_,_ in metas])
+        for meta,_,_ in metas:
+            master_build_numbers[meta.meta['package']['name']] = {"version" : meta.meta['package']['version'],
+                                                                  "number" : meta.meta['build']['number']}
 
     utils.run_and_log("git checkout {}".format(pr_branch))
-    current_pr_build_numbers = set()
+    current_pr_build_numbers = dict()
     for recipe in build_config_data["recipes"]:
         metas = conda_build.api.render(recipe['path'],
                                     config=config,
                                     variants=variants[0],
                                     bypass_env_check=True,
                                     finalize=False)
-        current_pr_build_numbers.update([(meta.meta['package']['name'],
-                                          meta.meta['package']['version'],
-                                          meta.meta['build']['number']) for meta,_,_ in metas])
+        for meta,_,_ in metas:
+            current_pr_build_numbers[meta.meta['package']['name']] = {"version" : meta.meta['package']['version'],
+                                                                      "number" : meta.meta['build']['number']}
 
-    if current_pr_build_numbers == master_build_numbers:
-        print("There is no change in version or build numbers.")
-        print(current_pr_build_numbers)
-        print(master_build_numbers)
-        return 1
+    print("Current PR Build Info:    ", current_pr_build_numbers)
+    print("Master Branch Build Info: ", master_build_numbers)
 
-    return 0
+    #No build numbers can go backwards without a version change.
+    for package in master_build_numbers:
+        if package in current_pr_build_numbers and current_pr_build_numbers[package]["version"] == master_build_numbers[package]["version"]:
+            assert int(current_pr_build_numbers[package]["number"]) >= int(master_build_numbers[package]["number"]), "If the version doesn't change, the build number can't be reduced."
+
+    #If packages are added or removed, don't require a version change
+    if set(master_build_numbers.keys()) != set(current_pr_build_numbers.keys()):
+        return
+
+    #At least one package needs to increase the build number or change the version.
+    checks = [current_pr_build_numbers[package]["version"] != master_build_numbers[package]["version"] or
+              int(current_pr_build_numbers[package]["number"]) > int(master_build_numbers[package]["number"])
+                  for package in master_build_numbers]
+    assert all(checks), "At least one package needs to increase the build number or change the version."
 
 if __name__ == '__main__':
-    sys.exit(feedstock_pr())
+    try:
+        main()
+        print("BUILD NUMBER SUCCESS")
+    except Exception as exc:
+        print("BUILD NUMBER ERROR: ", exc)
+        sys.exit(1)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Improves the build number check on feedstock PRs. Now instead of just checking for a change in build/number or version, the following tests are performed.

1. Disallowing build number decrements unless the version is changed.
1. Ensuring that at least one of the following happened in the PR:
    1. a package is added/removed
    1. a version number is changed for a package
    1. a package's build number is _increased_

Some possible future additions:
1. If a version is changed, the build number has to be reset to `1`.
1. We could add version parsing to make sure that the version is only ever increased.