### PR TITLE
Use any instead of all for build number check.

### DIFF
--- a/tests/feedstock_tests/check_build_numbers.py
+++ b/tests/feedstock_tests/check_build_numbers.py
@@ -91,7 +91,7 @@ def main(arg_strings=None):
     checks = [current_pr_build_numbers[package]["version"] != master_build_numbers[package]["version"] or
               int(current_pr_build_numbers[package]["number"]) > int(master_build_numbers[package]["number"])
                   for package in master_build_numbers]
-    assert all(checks), "At least one package needs to increase the build number or change the version."
+    assert any(checks), "At least one package needs to increase the build number or change the version."
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
@cdeepali Found that we should be using any here instead of all.