### PR TITLE
Intial commit of test_feedstock script

### DIFF
--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+"""
+*****************************************************************
+Licensed Materials - Property of IBM
+(C) Copyright IBM Corp. 2020. All Rights Reserved.
+US Government Users Restricted Rights - Use, duplication or
+disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+*****************************************************************
+"""
+
+import datetime
+import os
+import tempfile
+import sys
+import subprocess
+
+import yaml
+
+import utils
+from utils import OpenCEError
+
+class TestCommand():
+    """
+    Contains a test to run within a given conda environment.
+
+    Args:
+        name (str): The name describing the test.
+        conda_env (str): The name of the conda environment that the test will be run in.
+        bash_command (str): The bash command to run.
+        create_env (bool): Whether this is the command to create a new conda environment.
+        clean_env (bool): Whether this is the command to remove a conda environment.
+    """
+    #pylint: disable=too-many-arguments
+    def __init__(self, name, conda_env=None, bash_command="", create_env=False, clean_env=False):
+        self.bash_command = bash_command
+        self.conda_env = conda_env
+        self.name = name
+        self.create_env = create_env
+        self.clean_env = clean_env
+
+    def get_test_command(self, conda_env_file=None):
+        """"
+        Returns a string of the test command.
+
+        Args:
+            conda_env_file (str): The name of the original conda environment file.
+                                  This is only needed when create_env is True.
+        """
+        output = ""
+        if self.create_env:
+            output += "conda env create -f " + conda_env_file + " -n " + self.conda_env + "\n"
+            return output
+
+        if self.clean_env:
+            output += "conda env remove -y -n " + self.conda_env + "\n"
+            return output
+
+        output += "CONDA_BIN=$(dirname $(which conda))\n"
+        output += "source ${CONDA_BIN}/../etc/profile.d/conda.sh\n"
+        output += "conda activate " + self.conda_env + "\n"
+        output += self.bash_command + "\n"
+
+        return output
+
+    def run(self, conda_env_file):
+        """
+        Runs the test.
+
+        Creates a temporary bash file, and writes the contents to `get_test_command` into it.
+        Runs the generated bash file.
+        Removes the temporary bash file.
+
+        Args:
+            conda_env_file (str): The name of the original conda environment file.
+        """
+        print("Running: " + self.name)
+        # Create file containing bash commands
+        with tempfile.NamedTemporaryFile(mode='w+t', dir=os.getcwd(), delete=False) as temp:
+            temp.write("set -e\n")
+            temp.write(self.get_test_command(conda_env_file))
+            temp_file_name = temp.name
+
+        # Execute file
+        test_process = subprocess.run(["bash", temp_file_name], stdout=subprocess.PIPE, check=False,
+                                      stderr=subprocess.STDOUT, universal_newlines=True)
+
+        # Remove file containing bash commands
+        os.remove(temp_file_name)
+
+        result = TestResult(self.name, test_process.returncode, test_process.stdout)
+
+        if test_process.returncode != 0:
+            result.display_failed()
+
+        return result
+
+class TestResult():
+    """
+    Contains the results of running a test.
+
+    Args:
+        name (str): The name of the test that was run.
+        returncode (int): The return code of the test that was run.
+        output (str): The resuling output from running the test.
+    """
+    def __init__(self, name, returncode, output):
+        self.name = name
+        self.output = output
+        self.returncode = returncode
+
+    def display_failed(self):
+        """
+        Display the output from a failed test.
+        """
+        if self.failed():
+            print("--------------------------------")
+            print("Failed test: " + self.name)
+            print(self.output)
+            print("--------------------------------")
+
+    def failed(self):
+        """
+        Returns whether or not a test failed.
+        """
+        return self.returncode != 0
+
+def load_test_file(test_file):
+    """
+    Load a given test file.
+
+    Args:
+        test_file (str): Path to the test file to load.
+    """
+    with open(test_file, 'r') as stream:
+        test_file_data = yaml.safe_load(stream)
+
+    return test_file_data
+
+def gen_test_commands(test_file=utils.DEFAULT_TEST_CONFIG_FILE):
+    """
+    Generate a list of test commands from the provided test file.
+
+    Args:
+        test_file (str): Path to the test file.
+    """
+    test_data = load_test_file(test_file)
+
+    time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    conda_env = "open-ce-conda-env-" + time_stamp
+
+    test_commands = []
+
+    # Create conda environment for testing
+    test_commands.append(TestCommand(name="Create conda environment " + conda_env,
+                                     conda_env=conda_env,
+                                     create_env=True))
+
+    for test in test_data['tests']:
+        test_commands.append(TestCommand(name=test.get('name'), conda_env=conda_env, bash_command=test.get('command')))
+
+    test_commands.append(TestCommand(name="Remove conda environment " + conda_env,
+                                     conda_env=conda_env,
+                                     clean_env=True))
+
+    return test_commands
+
+def run_test_commands(conda_env_file, test_commands):
+    """
+    Run a list of tests within a conda environment.
+
+    Args:
+        conda_env_file (str): The name of the conda environment file used to create the conda environment.
+        test_commands (:obj:`list` of :obj:`TestCommand): List of test commands to run.
+    """
+    failed_tests = []
+    for test_command in test_commands:
+        test_result = test_command.run(conda_env_file)
+        if test_result.failed():
+            failed_tests.append(test_result)
+
+    return failed_tests
+
+def display_failed_tests(failed_tests):
+    """
+    Display a list of failed tests.
+
+    Args:
+        failed_tests (:obj:`list` of :obj:`TestResult`): A list of failed TestResult's.
+    """
+    # If any collected output, return 1, else return 0
+    if failed_tests:
+        for failed_test in failed_tests:
+            failed_test.display_failed()
+        print("The following tests failed: " + str([failed_test.name for failed_test in failed_tests]))
+    else:
+        print("All tests passed!")
+
+def make_parser():
+    ''' Parser for input arguments '''
+    arguments = [utils.Argument.CONDA_ENV_FILE]
+    parser = utils.make_parser(arguments, description = 'Test a feedstock as part of Open-CE')
+
+    return parser
+
+def test_feedstock(arg_strings=None):
+    '''
+    Entry function.
+    '''
+    parser = make_parser()
+    args = parser.parse_args(arg_strings)
+
+    test_commands = gen_test_commands()
+    failed_tests = run_test_commands(args.conda_env_file, test_commands)
+    display_failed_tests(failed_tests)
+
+    return len(failed_tests)
+
+if __name__ == '__main__':
+    try:
+        sys.exit(test_feedstock())
+    except OpenCEError as err:
+        print(err.msg, file=sys.stderr)
+        sys.exit(1)

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -146,7 +146,7 @@ def gen_test_commands(test_file=utils.DEFAULT_TEST_CONFIG_FILE):
     test_data = load_test_file(test_file)
 
     time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-    conda_env = "open-ce-conda-env-" + time_stamp
+    conda_env = utils.CONDA_ENV_FILENAME_PREFIX + time_stamp
 
     test_commands = []
 

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -27,6 +27,7 @@ SUPPORTED_GIT_PROTOCOLS = ["https:", "http:", "git@"]
 DEFAULT_RECIPE_CONFIG_FILE = "config/build-config.yaml"
 CONDA_ENV_FILENAME_PREFIX = "opence-conda-env-"
 DEFAULT_OUTPUT_FOLDER = "condabuild"
+DEFAULT_TEST_CONFIG_FILE = "tests/open-ce-tests.yaml"
 
 class OpenCEFormatter(argparse.ArgumentDefaultsHelpFormatter):
     """

--- a/tests/test-conda-env2.yaml
+++ b/tests/test-conda-env2.yaml
@@ -1,0 +1,5 @@
+channels:
+- defaults
+dependencies:
+- pytest
+name: opence-conda-env-py3.6-cuda-openmpi

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -1,0 +1,58 @@
+# *****************************************************************
+#
+# Licensed Materials - Property of IBM
+#
+# (C) Copyright IBM Corp. 2020. All Rights Reserved.
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# *****************************************************************
+
+import sys
+import os
+import pathlib
+import pytest
+
+test_dir = pathlib.Path(__file__).parent.absolute()
+sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
+
+import test_feedstock
+
+def test_test_feedstock(mocker, capsys):
+    '''
+    This is a complete test of `test_feedstock`.
+    '''
+
+    test_file = {"tests":
+                    [{"name" : "Test 1", "command" : "echo Test 1"},
+                    {"name" : "Test 2", "command" : "echo Test 2a\necho Test2b"}]}
+
+    mocker.patch('yaml.safe_load', return_value=test_file)
+    mocker.patch('builtins.open', side_effect=None)
+
+    assert test_feedstock.test_feedstock(["--conda_env_file", "tests/test-conda-env2.yaml"]) == 0
+    captured = capsys.readouterr()
+    assert "Running: Create conda environment open-ce-conda-env-" in captured.out
+    assert "Running: Test 1" in captured.out
+    assert "Running: Test 2" in captured.out
+    assert "Running: Remove conda environment open-ce-conda-env-" in captured.out
+
+def test_test_feedstock_failed_tests(mocker, capsys):
+    '''
+    Test that failed tests work correctly.
+    '''
+
+    test_file = {"tests":
+                    [{"name" : "Test 1", "command" : "[ 1 -eq 2 ]"},
+                    {"name" : "Test 2", "command" : "[ 1 -eq 1 ]"},
+                    {"name" : "Test 3", "command" : "[ 1 -eq 3 ]"}]}
+
+    mocker.patch('yaml.safe_load', return_value=test_file)
+    mocker.patch('builtins.open', side_effect=None)
+
+    assert test_feedstock.test_feedstock(["--conda_env_file", "tests/test-conda-env2.yaml"]) == 2
+    captured = capsys.readouterr()
+    assert "Failed test: Test 1" in captured.out
+    assert "Failed test: Test 3" in captured.out
+    assert not "Failed test: Test 2" in captured.out

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -17,6 +17,7 @@ test_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
 
 import test_feedstock
+import utils
 
 def test_test_feedstock(mocker, capsys):
     '''
@@ -32,10 +33,10 @@ def test_test_feedstock(mocker, capsys):
 
     assert test_feedstock.test_feedstock(["--conda_env_file", "tests/test-conda-env2.yaml"]) == 0
     captured = capsys.readouterr()
-    assert "Running: Create conda environment open-ce-conda-env-" in captured.out
+    assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in captured.out
     assert "Running: Test 1" in captured.out
     assert "Running: Test 2" in captured.out
-    assert "Running: Remove conda environment open-ce-conda-env-" in captured.out
+    assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in captured.out
 
 def test_test_feedstock_failed_tests(mocker, capsys):
     '''

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -12,7 +12,6 @@
 import sys
 import os
 import pathlib
-import pytest
 
 test_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.append(os.path.join(test_dir, '..', 'open-ce'))


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #114.

This adds the initial version of the test_feedstock script. This script will read an Open-CE test file for a feedstock and run all of the commands within that file. All of the tests will be run within a conda environment created from the provided conda environment file.

In order to run tests for a repository:
1. `git clone https://github.com/open-ce/open-ce.git`
1. `git clone https://github.com/open-ce/MY_REPO.git`
1. `cd MY_REPO`
1. `../open-ce/test_feedstock.py --conda_env_file MY_CONDA_ENV_FILE`

For an example of the test file, please see: https://github.com/open-ce/xgboost-feedstock/pull/10

Some future work will include:
* Adding  a script that will run all of the tests for a given Open-CE environment file.
* Adding some sort of label to the tests that will signify whether they are short or long tests (or anything else).
* Specifying a directory that tests should be run from.
* Adding documentation for how to run tests and what a test file should look like.
* Verify that test files are valid.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
