### PR TITLE
Save conda env file to output folder.

### DIFF
--- a/open-ce/conda_env_file_generator.py
+++ b/open-ce/conda_env_file_generator.py
@@ -35,7 +35,7 @@ class CondaEnvFileGenerator():
                              channels=None,
                              output_folder=None,
                              env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
-                             path=os.getcwd()):
+                             path=utils.DEFAULT_OUTPUT_FOLDER ):
         """
         This function writes conda environment files using the dependency dictionary
         created from all the buildcommands.

--- a/open-ce/docker_build.py
+++ b/open-ce/docker_build.py
@@ -28,7 +28,7 @@ DOCKER_TOOL = "docker"
 
 def make_parser():
     ''' Parser for input arguments '''
-    arguments = [utils.Argument.DOCKER_BUILD]
+    arguments = [utils.Argument.DOCKER_BUILD, utils.Argument.OUTPUT_FOLDER]
     parser = utils.make_parser(arguments, description='Run Open-CE tools within a container')
 
     return parser
@@ -74,7 +74,8 @@ def _create_container(container_name, image_name, output_folder):
     docker_cmd = DOCKER_TOOL + " create -i --rm --name " + container_name + " "
 
     # Add output folder
-    docker_cmd += _add_volume(os.path.join(os.getcwd(), output_folder), os.path.join(HOME_PATH, output_folder))
+    docker_cmd += _add_volume(os.path.abspath(output_folder),
+                              os.path.abspath(os.path.join(HOME_PATH, utils.DEFAULT_OUTPUT_FOLDER)))
 
     # Add cache directory
     docker_cmd += _add_volume(None, os.path.join(HOME_PATH, ".cache"))

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -15,6 +15,7 @@ import errno
 from enum import Enum, unique
 from itertools import product
 import re
+import yaml
 import pkg_resources
 from errors import OpenCEError, Error
 
@@ -319,3 +320,16 @@ def is_subdir(child_path, parent_path):
 
     relative = os.path.relpath(child, start=parent)
     return not relative.startswith(os.pardir)
+
+def replace_conda_env_channels(conda_env_file, original_channel, new_channel):
+    '''
+    Use regex to substitute channels in a conda env file.
+    Regex 'original_channel' is replaced with 'new_channel'
+    '''
+    with open(conda_env_file, 'r') as file_handle:
+        env_info = yaml.safe_load(file_handle)
+
+    env_info['channels'] = [re.sub(original_channel, new_channel, channel) for channel in env_info['channels']]
+
+    with open(conda_env_file, 'w') as file_handle:
+        yaml.safe_dump(env_info, file_handle)

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -156,7 +156,7 @@ def validate_conda_env_files(py_versions=utils.DEFAULT_PYTHON_VERS,
     # Check if conda env files are created for given python versions and build variants
     variants = utils.make_variants(py_versions, build_types, mpi_types)
     for variant in variants:
-        cuda_env_file = os.path.join(os.getcwd(),
+        cuda_env_file = os.path.join(os.getcwd(), utils.DEFAULT_OUTPUT_FOLDER,
                                      "{}{}.yaml".format(utils.CONDA_ENV_FILENAME_PREFIX,
                                      utils.variant_string(variant['python'], variant['build_type'], variant['mpi_type'], variant['cudatoolkit'])))
 

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -51,10 +51,6 @@ def test_build_env(mocker):
     '''
     dirTracker = helpers.DirTracker()
     mocker.patch(
-        'os.mkdir',
-        return_value=0 #Don't worry about making directories.
-    )
-    mocker.patch(
         'os.system',
         side_effect=(lambda x: helpers.validate_cli(x, expect=["git clone"], retval=0)) #At this point all system calls are git clones. If that changes this should be updated.
     )


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #126 

I changed the output location for the conda env files to be the build output directory. This ensures that it is available outside of the docker container after a build.
