### PR TITLE
Enable skip build

### DIFF
--- a/doc/README.build_env.md
+++ b/doc/README.build_env.md
@@ -63,8 +63,9 @@ usage: build_env.py [-h] [--conda_build_config CONDA_BUILD_CONFIG]
                     [--repository_folder REPOSITORY_FOLDER]
                     [--python_versions PYTHON_VERSIONS]
                     [--build_types BUILD_TYPES] [--mpi_types MPI_TYPES]
+                    [--skip_build_packages] [--docker_build]
                     [--git_location GIT_LOCATION]
-                    [--git_tag_for_env GIT_TAG_FOR_ENV] [--docker_build]
+                    [--git_tag_for_env GIT_TAG_FOR_ENV]
                     env_config_file [env_config_file ...]
 
 Build conda environment as part of Open-CE
@@ -78,8 +79,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --conda_build_config CONDA_BUILD_CONFIG
                         Location of conda_build_config.yaml file. (default:
-                        /mnt/pai/home/bnelson/git/open-ce/open-
-                        ce/../conda_build_config.yaml)
+                        conda_build_config.yaml)
   --output_folder OUTPUT_FOLDER
                         Path where built conda packages will be saved.
                         (default: condabuild)
@@ -100,17 +100,19 @@ optional arguments:
   --mpi_types MPI_TYPES
                         Comma delimited list of mpi types, such as "openmpi"
                         or "system". (default: openmpi)
-  --git_location GIT_LOCATION
-                        The default location to clone git repositories from.
-                        (default: https://github.com/open-ce)
-  --git_tag_for_env GIT_TAG_FOR_ENV
-                        Git tag to be checked out for all of the packages in
-                        an environment. (default: None)
+  --skip_build_packages
+                        Do not perform builds of packages. (default: False)
   --docker_build        Perform a build within a docker container. NOTE: When
                         the --docker_build flag is used, all arguments with
                         paths should be relative to the directory containing
                         open-ce. Only files within the open-ce directory and
                         local_files will be visible at build time. (default:
                         False)
+  --git_location GIT_LOCATION
+                        The default location to clone git repositories from.
+                        (default: https://github.com/open-ce)
+  --git_tag_for_env GIT_TAG_FOR_ENV
+                        Git tag to be checked out for all of the packages in
+                        an environment. (default: None)
 ==============================================================================
 ```

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -239,7 +239,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 variant_recipes, external_deps = self._create_all_recipes(variant)
             except OpenCEError as exc:
                 raise OpenCEError(Error.CREATE_BUILD_TREE, exc.msg) from exc
-            variant_string = utils.variant_string(variant["python"], variant["build_type"], variant["mpi_type"], variant["cudatoolkit"])
+            variant_string = utils.variant_string(variant["python"], variant["build_type"],
+                                                  variant["mpi_type"], variant["cudatoolkit"])
             self._external_dependencies[variant_string] = external_deps
             self._conda_env_files[variant_string] = CondaEnvFileGenerator(variant_recipes, external_deps)
 
@@ -357,7 +358,8 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
     def get_external_dependencies(self, variant):
         '''Return the list of external dependencies for the given variant.'''
-        variant_string = utils.variant_string(variant["python"], variant["build_type"], variant["mpi_type"])
+        variant_string = utils.variant_string(variant["python"], variant["build_type"],
+                                              variant["mpi_type"], variant["cudatoolkit"])
         return self._external_dependencies.get(variant_string, [])
 
     def write_conda_env_files(self,

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -12,6 +12,7 @@ import utils
 import env_config
 import build_feedstock
 from errors import OpenCEError, Error
+from conda_env_file_generator import CondaEnvFileGenerator
 
 import conda_build.api
 from conda_build.config import get_or_merge_config
@@ -227,6 +228,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         self._git_tag_for_env = git_tag_for_env
         self._conda_build_config = conda_build_config
         self._external_dependencies = dict()
+        self._conda_env_files = dict()
 
         # Create a dependency tree that includes recipes for every combination
         # of variants.
@@ -237,8 +239,10 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                 variant_recipes, external_deps = self._create_all_recipes(variant)
             except OpenCEError as exc:
                 raise OpenCEError(Error.CREATE_BUILD_TREE, exc.msg) from exc
+            variant_string = utils.variant_string(variant["python"], variant["build_type"], variant["mpi_type"], variant["cudatoolkit"])
+            self._external_dependencies[variant_string] = external_deps
+            self._conda_env_files[variant_string] = CondaEnvFileGenerator(variant_recipes, external_deps)
 
-            self._external_dependencies[str(variant)] = external_deps
             # Add dependency tree information to the packages list
             _add_build_command_dependencies(variant_recipes, len(self.build_commands))
             self.build_commands += variant_recipes
@@ -353,7 +357,23 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
     def get_external_dependencies(self, variant):
         '''Return the list of external dependencies for the given variant.'''
-        return self._external_dependencies.get(str(variant), [])
+        variant_string = utils.variant_string(variant["python"], variant["build_type"], variant["mpi_type"])
+        return self._external_dependencies.get(variant_string, [])
+
+    def write_conda_env_files(self,
+                              channels=None,
+                              output_folder=None,
+                              env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
+                              path=os.getcwd()):
+        """
+        Write a conda environment file for each variant.
+        """
+        conda_env_files = []
+        for variant, conda_env_file in self._conda_env_files.items():
+            conda_env_files += conda_env_file.write_conda_env_file(variant, channels,
+                                                                   output_folder, env_file_prefix, path)
+
+        return conda_env_files
 
     def _detect_cycle(self, max_cycles=10):
         extract_build_tree = [x.build_command_dependencies for x in self.build_commands]

--- a/open-ce/conda_env_file_generator.py
+++ b/open-ce/conda_env_file_generator.py
@@ -8,91 +8,83 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 """
 
 import os
+
 import yaml
 import utils
 
+#pylint: disable=too-few-public-methods
 class CondaEnvFileGenerator():
     """
     The CondaEnvData class holds all of the information needed to generate a conda
     environment file that can be used to create a conda environment from the built packages.
     """
 
-    #pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(self,
-                 python_versions=utils.DEFAULT_PYTHON_VERS,
-                 build_types=utils.DEFAULT_BUILD_TYPES,
-                 mpi_types=utils.DEFAULT_MPI_TYPES,
-                 cuda_versions=utils.DEFAULT_CUDA_VERS,
-                 channels=None,
-                 output_folder=None,
-                 env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
+                 build_commands,
+                 external_dependencies,
                  ):
-        self.python_versions = utils.parse_arg_list(python_versions)
-        self.build_types = utils.parse_arg_list(build_types)
-        self.mpi_types= utils.parse_arg_list(mpi_types)
-        self.cuda_versions = utils.parse_arg_list(cuda_versions)
-        self.env_file_prefix = env_file_prefix
-        self.dependency_dict = {}
-        self.channels = []
-        self._initialize_dependency_dict()
-        self._initialize_channels(channels, output_folder)
+        self._dependency_set = set()
+        self._external_dependencies = external_dependencies
 
-    def _initialize_dependency_dict(self):
-        variants = utils.make_variants(self.python_versions, self.build_types, self.mpi_types, self.cuda_versions)
-        for variant in variants:
-            key = utils.variant_string(variant['python'], variant['build_type'], variant['mpi_type'], variant['cudatoolkit'])
-            self.dependency_dict[key] = set()
+        for build_command in build_commands:
+            self._update_conda_env_file_content(build_command)
 
-    def _initialize_channels(self, channels, output_folder):
-        self.channels.append("file:/" + output_folder)
-        if channels is None:
-            channels = []
-        for channel in channels:
-            self.channels.append(channel)
-        self.channels.append("defaults")
-
-    def write_conda_env_files(self, path=os.getcwd()):
+    #pylint: disable=too-many-arguments
+    def write_conda_env_file(self,
+                             variant_string,
+                             channels=None,
+                             output_folder=None,
+                             env_file_prefix=utils.CONDA_ENV_FILENAME_PREFIX,
+                             path=os.getcwd()):
         """
         This function writes conda environment files using the dependency dictionary
         created from all the buildcommands.
+
+        It returns a list of paths to the files that were writeen.
         """
 
         conda_env_files = []
-        for key in self.dependency_dict:
-            if len(self.dependency_dict[key]) == 0:
-                continue
-            if not os.path.exists(path):
-                os.mkdir(path)
-            conda_env_name = self.env_file_prefix + key
-            conda_env_file = conda_env_name + ".yaml"
-            conda_env_file = os.path.join(path, conda_env_file)
-            data = dict(
-                name = conda_env_name,
-                channels = self.channels,
-                dependencies = self.dependency_dict[key],
-            )
-            with open(conda_env_file, 'w') as outfile:
-                yaml.dump(data, outfile, default_flow_style=False)
-                conda_env_files.append(conda_env_file)
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+        conda_env_name = env_file_prefix + variant_string
+        conda_env_file = conda_env_name + ".yaml"
+        conda_env_file = os.path.join(path, conda_env_file)
+
+        channels = _create_channels(channels, output_folder)
+
+        data = dict(
+            name = conda_env_name,
+            channels = channels,
+            dependencies = self._dependency_set,
+        )
+        with open(conda_env_file, 'w') as outfile:
+            yaml.dump(data, outfile, default_flow_style=False)
+            conda_env_files.append(conda_env_file)
 
         return conda_env_files
 
-    def _update_deps_lists(self, dependencies, key):
+    def _update_deps_lists(self, dependencies):
         if not dependencies is None:
             for dep in dependencies:
-                self.dependency_dict[key].add(utils.generalize_version(dep))
+                self._dependency_set.add(utils.generalize_version(dep))
 
-    def update_conda_env_file_content(self, build_command, build_tree):
+    def _update_conda_env_file_content(self, build_command):
         """
         This function updates dependency dictionary for each build command with
         its dependencies both internal and external.
         """
-        key = utils.variant_string(build_command.python, build_command.build_type, build_command.mpi_type,
-        build_command.cudatoolkit)
+        self._update_deps_lists(build_command.run_dependencies)
+        self._update_deps_lists(build_command.packages)
 
-        self._update_deps_lists(build_command.run_dependencies, key)
-        self._update_deps_lists(build_command.packages, key)
+        self._update_deps_lists(self._external_dependencies)
 
-        variant = { 'python' : build_command.python, 'build_type' : build_command.build_type,
-                    'mpi_type' : build_command.mpi_type , 'cudatoolkit' : build_command.cudatoolkit}
-        self._update_deps_lists(build_tree.get_external_dependencies(str(variant)), key)
+def _create_channels(channels, output_folder):
+    result = []
+
+    result.append("file:/" + output_folder)
+    if channels:
+        result += channels
+    result.append("defaults")
+
+    return result

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -118,6 +118,12 @@ class Argument(Enum):
                                              "should be relative to the directory containing open-ce. Only files "
                                              "within the open-ce directory and local_files will be visible at "
                                              "build time."))
+
+    SKIP_BUILD_PACKAGES = (lambda parser: parser.add_argument(
+                                        '--skip_build_packages',
+                                        action='store_true',
+                                        help="Do not perform builds of packages."))
+
     CONDA_ENV_FILE = (lambda parser: parser.add_argument(
                                         '--conda_env_file',
                                         type=str,

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -19,40 +19,6 @@ sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
 
 import build_tree
 import conda_env_file_generator
-import utils
-
-class TestBuildTree(build_tree.BuildTree):
-    '''
-    Test class that inherits BuildTree class
-    '''
-    __test__ = False
-    def __init__(self,
-                 env_config_files,
-                 python_versions,
-                 build_types,
-                 mpi_types,
-                 cuda_versions,
-                 external_depends=None,
-                 repository_folder="./",
-                 git_location=utils.DEFAULT_GIT_LOCATION,
-                 git_tag_for_env="master",
-                 conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG):
-        super().__init__(env_config_files, python_versions, build_types, mpi_types,
-                         cuda_versions, repository_folder, git_location, conda_build_config)
-        if external_depends:
-            self._external_dependencies = external_depends
-        else:
-            dict()
-
-class TestCondaEnvFileGenerator(conda_env_file_generator.CondaEnvFileGenerator):
-    '''
-    Test class that inherits CondaEnvFileGenerator class
-    '''
-    __test__ = False
-    def __init__(self,
-                 build_commands,
-                 external_dependencies):
-        super().__init__(build_commands, exteranl_dependencies)
 
 sample_build_commands = [build_tree.BuildCommand("recipe1",
                                     "repo1",
@@ -88,133 +54,32 @@ sample_build_commands = [build_tree.BuildCommand("recipe1",
                                     run_dependencies=["pack1==1.0", "pack2 <=2.0", "pack3-suffix 3.0"])]
 
 
-external_deps = {}
-possible_variants = utils.make_variants(['3.6', '3.7'], ['cpu', 'cuda'], 'openmpi', '10.2')
-for variant in possible_variants:
-    external_deps[str(variant)] = ["external_pac1    1.2", "external_pack2", "external_pack3=1.2.3"]
-TMP_OPENCE_DIR="/tmp/opence-test/"
+external_deps = ["external_pac1    1.2", "external_pack2", "external_pack3=1.2.3"]
 
 def test_conda_env_file_content():
     '''
     Tests that the conda env file content are being populated correctly
     '''
-    python_versions = "3.6,3.7"
-    build_types = "cpu,cuda"
-    mpi_types = "openmpi,system"
-    cuda_versions = "10.2"
-    mock_build_tree = TestBuildTree([], python_versions, build_types, mpi_types, cuda_versions, external_deps)
-    mock_build_tree.build_commands = sample_build_commands
+    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator([sample_build_commands[0]], external_deps)
+    expected_deps = set(["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a", "package1b",
+                      "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
+    assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
 
+    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator([sample_build_commands[1]], [])
+    expected_deps = set(["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a", "pack3 3.3.* build"])
+    assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
+
+    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator([sample_build_commands[2]], external_deps)
+    expected_deps = set(["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a", "package3b",
+                     "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"])
+    assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
+
+    mock_conda_env_file_generator = conda_env_file_generator.CondaEnvFileGenerator([sample_build_commands[3]], [])
+    expected_deps = set(["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a", "package4b"])
+    assert Counter(expected_deps) == Counter(mock_conda_env_file_generator._dependency_set)
+
+def test_create_channels():
     output_dir = os.path.join(test_dir, '../condabuild' )
-    mock_conda_env_file_generator = CondaEnvFileGenerator([sample_build_commands[0]], [])
+    expected_channels = ["file:/{}".format(output_dir), "some channel", "defaults"]
 
-    variants = utils.make_variants(python_versions, build_types, mpi_types)
-    expected_keys = [utils.variant_string(variant['python'], variant['build_type'], variant['mpi_type'], variant['cudatoolkit'])
-                     for variant in variants]
-    actual_keys = list(mock_conda_env_file_generator.dependency_dict.keys())
-    assert Counter(actual_keys) == Counter(expected_keys)
-
-    for build_command in mock_build_tree:
-        mock_conda_env_file_generator.update_conda_env_file_content(build_command, mock_build_tree)
-
-    files_generated_for_keys = []
-    validate_dependencies(mock_conda_env_file_generator, expected_keys, files_generated_for_keys)
-    mock_conda_env_file_generator.write_conda_env_files(TMP_OPENCE_DIR)
-
-    # Check if conda env files are created for all variants
-    for key in files_generated_for_keys:
-        cuda_env_file = os.path.join(TMP_OPENCE_DIR,
-                            "{}{}.yaml".format(utils.CONDA_ENV_FILENAME_PREFIX,
-                                               key))
-        assert os.path.exists(cuda_env_file)
-
-    cleanup()
-    assert not os.path.exists(TMP_OPENCE_DIR)
-
-def validate_dependencies(env_file_generator, variant_keys, files_generated_for):
-    '''
-    Validates the exact dependencies for each environment
-    '''
-    py36_cpu_openmpi_deps = set()
-    actual_deps = env_file_generator.dependency_dict[variant_keys[0]]
-    assert Counter(py36_cpu_openmpi_deps) == Counter(actual_deps)
-
-    py36_cpu_system_deps = ["python ==3.6.*", "pack1 >=1.0", "pack2 ==2.0.*", "package2a", "pack3 3.3.* build"]
-    actual_deps = env_file_generator.dependency_dict[variant_keys[1]]
-    assert Counter(py36_cpu_system_deps) == Counter(actual_deps)
-    files_generated_for.append(variant_keys[1])
-
-    py36_cuda_openmpi_deps = ["python >=3.6", "pack1 1.0.*", "pack2 >=2.0", "package1a", "package1b",
-                      "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"]
-    actual_deps = env_file_generator.dependency_dict[variant_keys[2]]
-    assert Counter(py36_cuda_openmpi_deps) == Counter(actual_deps)
-    files_generated_for.append(variant_keys[2])
-
-    py36_cuda_system_deps = set()
-    actual_deps = env_file_generator.dependency_dict[variant_keys[3]]
-    assert Counter(py36_cuda_system_deps) == Counter(actual_deps)
-
-    py37_cpu_openmpi_deps = ["python 3.7.*", "pack1==1.0.*", "pack2 <=2.0", "pack3 3.0.*", "package3a", "package3b",
-                     "external_pac1 1.2.*", "external_pack2", "external_pack3=1.2.3"]
-    actual_deps = env_file_generator.dependency_dict[variant_keys[4]]
-    assert Counter(py37_cpu_openmpi_deps) == Counter(actual_deps)
-    files_generated_for.append(variant_keys[4])
-
-    py37_cpu_system_deps = set()
-    actual_deps = env_file_generator.dependency_dict[variant_keys[5]]
-    assert Counter(py37_cpu_system_deps) == Counter(actual_deps)
-
-    py37_cuda_openmpi_deps = set()
-    actual_deps = env_file_generator.dependency_dict[variant_keys[6]]
-    assert Counter(py37_cuda_openmpi_deps) == Counter(actual_deps)
-
-    py37_cuda_system_deps = ["pack1==1.0.*", "pack2 <=2.0", "pack3-suffix 3.0.*", "package4a", "package4b"]
-    actual_deps = env_file_generator.dependency_dict[variant_keys[7]]
-    assert Counter(py37_cuda_system_deps) == Counter(actual_deps)
-    files_generated_for.append(variant_keys[7])
-
-def test_conda_env_file_for_inapplicable_conf():
-    '''
-    Tests that the conda env file is not generated if build is triggered for
-    inapplicable configurations. For e.g. cpu variant build is selected for cuda only
-    packages like TensorRT
-    '''
-    python_versions = "3.7"
-    build_types = "cuda"
-    mpi_types = "openmpi"
-    cuda_versions = "10.2"
-    mock_build_tree = TestBuildTree([], python_versions, build_types, mpi_types, cuda_versions)
-
-    mock_build_tree.build_commands = [build_tree.BuildCommand("recipe1",
-                                      "repo1",
-                                      [], # packages is intentionally kept empty
-                                      python=python_versions,
-                                      build_type=build_types,
-                                      mpi_type=mpi_types,
-                                      cudatoolkit=cuda_versions,
-                                      run_dependencies=None)]
-
-    output_dir = os.path.join(test_dir, '../condabuild' )
-    mock_conda_env_file_generator = TestCondaEnvFileGenerator(python_versions, build_types, mpi_types, cuda_versions, [], output_dir)
-
-    expected_keys = ["py3.7-cuda-openmpi-10.2"]
-    actual_keys = list(mock_conda_env_file_generator.dependency_dict.keys())
-    assert actual_keys == expected_keys
-
-    for build_command in mock_build_tree:
-        mock_conda_env_file_generator.update_conda_env_file_content(build_command, mock_build_tree)
-
-    mock_conda_env_file_generator.write_conda_env_files(TMP_OPENCE_DIR)
-
-    # Check that no conda env file is created
-    for (root, _, _) in os.walk(TMP_OPENCE_DIR, topdown=True):
-        assert len(root) == 0
-
-    cleanup()
-    assert not os.path.exists(TMP_OPENCE_DIR)
-
-def cleanup():
-    '''
-    Deletes the temp directory in which conda env files are created during tests
-    '''
-    os.system("rm -rf {}".format(TMP_OPENCE_DIR))
+    assert expected_channels == conda_env_file_generator._create_channels(["some channel"], output_dir)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #142 

This PR adds the `--skip_build_packages` argument to the build_env script. This will perform all of the actions that build_env normally does except for performing the actual builds. Notably, this will generate conda environment files for a collection of Open-CE environments without actually performing a build.

As part of this PR, a collection of `CondaEnvFileGenerator`s will be stored within a `BuildTree`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
