### PR TITLE
Enable jinja within all Open-CE config files

### DIFF
--- a/open-ce/build_feedstock.py
+++ b/open-ce/build_feedstock.py
@@ -10,7 +10,6 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 
 import os
 import traceback
-import yaml
 
 import utils
 import inputs
@@ -22,6 +21,8 @@ utils.check_if_conda_build_exists()
 # pylint: disable=wrong-import-position
 import conda_build.api
 from conda_build.config import get_or_merge_config
+
+import conda_utils
 # pylint: enable=wrong-import-position
 
 COMMAND = 'feedstock'
@@ -43,7 +44,7 @@ def get_conda_build_config():
     recipe_conda_build_config = os.path.join(os.getcwd(), "config", "conda_build_config.yaml")
     return recipe_conda_build_config if os.path.exists(recipe_conda_build_config) else None
 
-def load_package_config(config_file=None):
+def load_package_config(config_file=None, variants=None):
     '''
     Check for a config file. If the user does not provide a recipe config
     file as an argument, it will be assumed that there is only one
@@ -58,8 +59,7 @@ def load_package_config(config_file=None):
         if not os.path.exists(config_file):
             raise OpenCEError(Error.CONFIG_FILE, config_file)
 
-        with open(config_file, 'r') as stream:
-            build_config_data = yaml.safe_load(stream)
+        build_config_data = conda_utils.render_yaml(config_file, variants)
 
     return build_config_data, config_file
 
@@ -104,37 +104,37 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments
         saved_working_directory = os.getcwd()
         os.chdir(os.path.abspath(command.repository))
 
-    build_config_data, recipe_config_file  = load_package_config(recipe_config_file)
-
     recipes_to_build = inputs.parse_arg_list(command.recipe)
 
-    # Build each recipe
-    for recipe in build_config_data['recipes']:
-        if recipes_to_build and recipe['name'] not in recipes_to_build:
-            continue
+    for variant in utils.make_variants(command.python, command.build_type, command.mpi_type, command.cudatoolkit):
+        build_config_data, recipe_config_file  = load_package_config(recipe_config_file, variant)
 
-        config = get_or_merge_config(None)
-        config.skip_existing = True
-        config.output_folder = output_folder
-        config.variant_config_files = [conda_build_config]
+        # Build each recipe
+        for recipe in build_config_data['recipes']:
+            if recipes_to_build and recipe['name'] not in recipes_to_build:
+                continue
 
-        recipe_conda_build_config = os.path.join(os.getcwd(), "config", "conda_build_config.yaml")
-        if os.path.exists(recipe_conda_build_config):
-            config.variant_config_files.append(recipe_conda_build_config)
+            config = get_or_merge_config(None)
+            config.skip_existing = True
+            config.output_folder = output_folder
+            config.variant_config_files = [conda_build_config]
 
-        config.channel_urls = extra_channels + command.channels + build_config_data.get('channels', [])
+            recipe_conda_build_config = os.path.join(os.getcwd(), "config", "conda_build_config.yaml")
+            if os.path.exists(recipe_conda_build_config):
+                config.variant_config_files.append(recipe_conda_build_config)
 
-        _set_local_src_dir(local_src_dir, recipe, recipe_config_file)
+            config.channel_urls = extra_channels + command.channels + build_config_data.get('channels', [])
 
-        try:
-            for variant in utils.make_variants(command.python, command.build_type, command.mpi_type, command.cudatoolkit):
+            _set_local_src_dir(local_src_dir, recipe, recipe_config_file)
+
+            try:
                 conda_build.api.build(os.path.join(os.getcwd(), recipe['path']),
                                config=config, variants=variant)
-        except Exception as exc: # pylint: disable=broad-except
-            traceback.print_exc()
-            raise OpenCEError(Error.BUILD_RECIPE,
-                              recipe['name'] if 'name' in recipe else os.getcwd,
-                              str(exc)) from exc
+            except Exception as exc: # pylint: disable=broad-except
+                traceback.print_exc()
+                raise OpenCEError(Error.BUILD_RECIPE,
+                                  recipe['name'] if 'name' in recipe else os.getcwd,
+                                  str(exc)) from exc
 
     if saved_working_directory:
         os.chdir(saved_working_directory)

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -9,14 +9,13 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 
 import os
 import utils
+import conda_utils
 import env_config
 import build_feedstock
 from errors import OpenCEError, Error
 from conda_env_file_generator import CondaEnvFileGenerator
 import test_feedstock
 
-import conda_build.api
-from conda_build.config import get_or_merge_config
 
 class BuildCommand():
     """
@@ -132,7 +131,7 @@ def _create_commands(repository, recipes, variant_config_files, variants, channe
                                            test_dependencies=test_deps,
                                            channels=channels if channels else []))
 
-    test_commands = test_feedstock.gen_test_commands()
+    test_commands = test_feedstock.gen_test_commands(variants=variants)
 
     os.chdir(saved_working_directory)
     return build_commands, test_commands
@@ -142,16 +141,7 @@ def _get_package_dependencies(path, variant_config_files, variants):
     Return a list of output packages and a list of dependency packages
     for the recipe at a given path. Uses conda-render to determine this information.
     """
-    # Call conda-build's render tool to get a list of dictionaries representing
-    # the recipe for each variant that will be built.
-    config = get_or_merge_config(None)
-    config.variant_config_files = variant_config_files
-    config.verbose = False
-    metas = conda_build.api.render(path,
-                                   config=config,
-                                   variants=variants,
-                                   bypass_env_check=True,
-                                   finalize=False)
+    metas = conda_utils.render_yaml(path, variants, variant_config_files)
 
     # Parse out the package names and dependencies from each variant
     packages = set()

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -105,7 +105,7 @@ def _create_commands(repository, recipes, variant_config_files, variants, channe
     saved_working_directory = os.getcwd()
     os.chdir(repository)
 
-    config_data, _ = build_feedstock.load_package_config()
+    config_data, _ = build_feedstock.load_package_config(variants=variants)
     combined_config_files = variant_config_files
 
     feedstock_conda_build_config_file = build_feedstock.get_conda_build_config()

--- a/open-ce/conda_env_file_generator.py
+++ b/open-ce/conda_env_file_generator.py
@@ -58,6 +58,7 @@ class CondaEnvFileGenerator():
             dependencies = self._dependency_set,
         )
         with open(conda_env_file, 'w') as outfile:
+            outfile.write("#" + utils.OPEN_CE_VARIANT + ":" + variant_string + "\n")
             yaml.dump(data, outfile, default_flow_style=False)
             file_name = conda_env_file
 
@@ -77,6 +78,20 @@ class CondaEnvFileGenerator():
         self._update_deps_lists(build_command.packages)
 
         self._update_deps_lists(self._external_dependencies)
+
+def get_variant_string(conda_env_file):
+    """
+    Return the variant string from a conda environment file that was added by CondaEnvFileGenerator.
+    If a variant string was not added to the conda environment file, None will be returned.
+    """
+    with open(conda_env_file, 'r') as stream:
+        first_line = stream.readline().strip()[1:]
+        values = first_line.split(':')
+        if values[0] == utils.OPEN_CE_VARIANT:
+            return values[1]
+
+    return None
+
 
 def _create_channels(channels, output_folder):
     result = []

--- a/open-ce/conda_utils.py
+++ b/open-ce/conda_utils.py
@@ -1,0 +1,34 @@
+"""
+*****************************************************************
+Licensed Materials - Property of IBM
+(C) Copyright IBM Corp. 2020. All Rights Reserved.
+US Government Users Restricted Rights - Use, duplication or
+disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+*****************************************************************
+"""
+import os
+
+import conda_build.api
+from conda_build.config import get_or_merge_config
+import conda_build.metadata
+
+def render_yaml(path, variants=None, variant_config_files=None):
+    """
+    Call conda-build's render tool to get a list of dictionaries of the
+    rendered YAML file for each variant that will be built.
+    """
+    config = get_or_merge_config(None)
+    config.variant_config_files = variant_config_files
+    config.verbose = False
+    if not os.path.isfile(path):
+        metas = conda_build.api.render(path,
+                                       config=config,
+                                       variants=variants,
+                                       bypass_env_check=True,
+                                       finalize=False)
+    else:
+        # api.render will only work if path is pointing to a meta.yaml file.
+        # For other files, use the MetaData class directly.
+        metas = conda_build.metadata.MetaData(path, variant=variants, config=config).get_rendered_recipe_text()
+
+    return metas

--- a/open-ce/conda_utils.py
+++ b/open-ce/conda_utils.py
@@ -8,9 +8,15 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 """
 import os
 
+import utils
+
+utils.check_if_conda_build_exists()
+
+# pylint: disable=wrong-import-position
 import conda_build.api
 from conda_build.config import get_or_merge_config
 import conda_build.metadata
+# pylint: enable=wrong-import-position
 
 def render_yaml(path, variants=None, variant_config_files=None):
     """
@@ -20,6 +26,7 @@ def render_yaml(path, variants=None, variant_config_files=None):
     config = get_or_merge_config(None)
     config.variant_config_files = variant_config_files
     config.verbose = False
+
     if not os.path.isfile(path):
         metas = conda_build.api.render(path,
                                        config=config,
@@ -29,6 +36,9 @@ def render_yaml(path, variants=None, variant_config_files=None):
     else:
         # api.render will only work if path is pointing to a meta.yaml file.
         # For other files, use the MetaData class directly.
-        metas = conda_build.metadata.MetaData(path, variant=variants, config=config).get_rendered_recipe_text()
+        # The absolute path is needed because MetaData seems to do some caching based on file name.
+        metas = conda_build.metadata.MetaData(os.path.abspath(path),
+                                              variant=variants,
+                                              config=config).get_rendered_recipe_text()
 
     return metas

--- a/open-ce/env_config.py
+++ b/open-ce/env_config.py
@@ -14,8 +14,7 @@ import utils
 from errors import OpenCEError, Error
 
 utils.check_if_conda_build_exists()
-
-import conda_build.metadata # pylint: disable=wrong-import-position, wrong-import-order
+import conda_utils  # pylint: disable=wrong-import-position, wrong-import-order
 
 @unique
 class Key(Enum):
@@ -47,10 +46,10 @@ _ENV_CONFIG_SCHEMA = {
 def _validate_config_file(env_file, variants):
     '''Perform some validation on the environment file after loading it.'''
     try:
-        meta_obj = conda_build.metadata.MetaData(env_file, variant=variants)
-        if not (Key.packages.name in meta_obj.meta.keys() or Key.imported_envs.name in meta_obj.meta.keys()):
+        meta_obj = conda_utils.render_yaml(env_file, variants=variants)
+        if not (Key.packages.name in meta_obj.keys() or Key.imported_envs.name in meta_obj.keys()):
             raise OpenCEError(Error.CONFIG_CONTENT)
-        utils.validate_dict_schema(meta_obj.meta, _ENV_CONFIG_SCHEMA)
+        utils.validate_dict_schema(meta_obj, _ENV_CONFIG_SCHEMA)
         return meta_obj
     except (Exception, SystemExit) as exc: #pylint: disable=broad-except
         raise OpenCEError(Error.ERROR, "Error in {}:\n  {}".format(env_file, str(exc))) from exc
@@ -66,8 +65,7 @@ def load_env_config_files(config_files, variants):
     while env_config_files:
         # Load the environment config files using conda-build's API. This will allow for the
         # filtering of text using selectors and jinja2 functions
-        meta_obj = _validate_config_file(env_config_files[0], variants)
-        env = meta_obj.get_rendered_recipe_text()
+        env = _validate_config_file(env_config_files[0], variants)
 
         # Examine all of the imported_envs items and determine if they still need to be loaded.
         new_config_files = []

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -31,6 +31,7 @@ DEFAULT_RECIPE_CONFIG_FILE = "config/build-config.yaml"
 CONDA_ENV_FILENAME_PREFIX = "opence-conda-env-"
 DEFAULT_OUTPUT_FOLDER = "condabuild"
 DEFAULT_TEST_CONFIG_FILE = "tests/open-ce-tests.yaml"
+OPEN_CE_VARIANT = "open-ce-variant"
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):
@@ -124,6 +125,18 @@ def variant_string(py_ver, build_type, mpi_type, cudatoolkit):
     if cudatoolkit:
         result += "-" + cudatoolkit
     return result
+
+def variant_string_to_dict(var_string):
+    """
+    Returns a dictionary of variants based on the versions within the variant string.
+    """
+    variants = var_string.split("-")
+    variant_dict = { 'python' : variants[0][2:],
+                     'build_type' : variants[1],
+                     'mpi_type' : variants[2],
+                     'cudatoolkit' : variants[3] }
+
+    return variant_dict
 
 def generalize_version(package):
     """Add `.*` to package versions when it is needed."""

--- a/tests/conda_env_file_generator_test.py
+++ b/tests/conda_env_file_generator_test.py
@@ -19,6 +19,7 @@ sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
 
 import build_tree
 import conda_env_file_generator
+import utils
 
 sample_build_commands = [build_tree.BuildCommand("recipe1",
                                     "repo1",
@@ -83,3 +84,16 @@ def test_create_channels():
     expected_channels = ["file:/{}".format(output_dir), "some channel", "defaults"]
 
     assert expected_channels == conda_env_file_generator._create_channels(["some channel"], output_dir)
+
+def test_get_variant_string(mocker):
+    var_str = "py3.6-cuda-openmpi-10.2"
+    test_env_file = "#" + utils.OPEN_CE_VARIANT + ":" + var_str + "\nsomething else"
+    mocker.patch('builtins.open', mocker.mock_open(read_data=test_env_file))
+
+    assert conda_env_file_generator.get_variant_string("some_file.yaml") == var_str
+
+def test_get_variant_string_no_string(mocker):
+    test_env_file = "some string without\n a variant string"
+    mocker.patch('builtins.open', mocker.mock_open(read_data=test_env_file))
+
+    assert conda_env_file_generator.get_variant_string("some_file.yaml") == None

--- a/tests/my_config.yaml
+++ b/tests/my_config.yaml
@@ -1,0 +1,4 @@
+recipes:
+  - name : my_variant
+    path: cuda_recipe_path #[build_type == 'cuda']
+    path: cpu_recipe_path #[build_type == 'cpu' ]

--- a/tests/open-ce-tests1.yaml
+++ b/tests/open-ce-tests1.yaml
@@ -1,0 +1,9 @@
+tests:
+  - name: Test 1
+    command: echo Test 1
+{% if build_type=='cpu' %}
+  - name: Test 2
+    command: |
+        echo Test 2a
+        echo Test 2b
+{% endif %}

--- a/tests/open-ce-tests2.yaml
+++ b/tests/open-ce-tests2.yaml
@@ -1,0 +1,7 @@
+tests:
+  - name: Test 1
+    command: "[ 1 -eq 2 ]"
+  - name: Test 2
+    command: "[ 1 -eq 1 ]"
+  - name: Test 3
+    command: "[ 1 -eq 3 ]"

--- a/tests/test-conda-env2.yaml
+++ b/tests/test-conda-env2.yaml
@@ -1,3 +1,4 @@
+#open-ce-variant:py3.6-cuda-openmpi-10.2
 channels:
 - defaults
 dependencies:

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -23,24 +23,22 @@ import test_feedstock
 import utils
 from errors import OpenCEError
 
+orig_load_test_file = test_feedstock.load_test_file
+def mock_load_test_file(x, y):
+    return orig_load_test_file(x, y)
+
 def test_test_feedstock(mocker, capsys):
     '''
     This is a complete test of `test_feedstock`.
     '''
 
-    test_file = {"tests":
-                    [{"name" : "Test 1", "command" : "echo Test 1"},
-                    {"name" : "Test 2", "command" : "echo Test 2a\necho Test2b"}]}
-
-    mocker.patch('os.path.exists', side_effect=(lambda x: x in (utils.DEFAULT_TEST_CONFIG_FILE, './')))
-    mocker.patch('yaml.safe_load', return_value=test_file)
-    mocker.patch('builtins.open', side_effect=None)
+    mocker.patch('test_feedstock.load_test_file', side_effect=(lambda x, y: mock_load_test_file(os.path.join(test_dir, "open-ce-tests1.yaml"), y)))
 
     open_ce._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml"])
     captured = capsys.readouterr()
     assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in captured.out
     assert "Running: Test 1" in captured.out
-    assert "Running: Test 2" in captured.out
+    assert not "Running: Test 2" in captured.out
     assert "Running: Remove conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in captured.out
 
 def test_test_feedstock_failed_tests(mocker, capsys):
@@ -48,14 +46,8 @@ def test_test_feedstock_failed_tests(mocker, capsys):
     Test that failed tests work correctly.
     '''
 
-    test_file = {"tests":
-                    [{"name" : "Test 1", "command" : "[ 1 -eq 2 ]"},
-                    {"name" : "Test 2", "command" : "[ 1 -eq 1 ]"},
-                    {"name" : "Test 3", "command" : "[ 1 -eq 3 ]"}]}
-
-    mocker.patch('os.path.exists', side_effect=(lambda x: x in (utils.DEFAULT_TEST_CONFIG_FILE, './')))
-    mocker.patch('yaml.safe_load', return_value=test_file)
-    mocker.patch('builtins.open', side_effect=None)
+    mocker.patch('test_feedstock.load_test_file', side_effect=(lambda x, y: mock_load_test_file(os.path.join(test_dir, "open-ce-tests2.yaml"), y)))
+    mocker.patch('conda_env_file_generator.get_variant_string', return_value=None)
 
     with pytest.raises(OpenCEError) as exc:
         open_ce._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml"])
@@ -68,20 +60,15 @@ def test_test_feedstock_failed_tests(mocker, capsys):
 def test_test_feedstock_working_dir(mocker, capsys):
     '''
     This tests that the working_dir arg works correctly.
+    Also sets a different build_type variant than what is in `test_test_feedstock`.
     '''
 
-    test_file = {"tests":
-                    [{"name" : "Test 1", "command" : "echo Test 1"},
-                    {"name" : "Test 2", "command" : "echo Test 2a\necho Test2b"}]}
-
     working_dir = "./my_working_dir"
-
-    mocker.patch('os.path.exists', side_effect=(lambda x: x == utils.DEFAULT_TEST_CONFIG_FILE or (x == working_dir and pathlib.Path(x).exists())))
-    mocker.patch('yaml.safe_load', return_value=test_file)
-    mocker.patch('builtins.open', side_effect=None)
+    my_variants = {'build_type' : 'cpu'}
+    mocker.patch('test_feedstock.load_test_file', side_effect=(lambda x, y: mock_load_test_file(os.path.join(test_dir, "open-ce-tests1.yaml"), my_variants)))
 
     assert not os.path.exists(working_dir)
-    open_ce._main(["test", test_feedstock.COMMAND, "--conda_env_file", "../tests/test-conda-env2.yaml", "--test_working_dir", working_dir])
+    open_ce._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_working_dir", working_dir])
     assert os.path.exists(working_dir)
     os.rmdir(working_dir)
     captured = capsys.readouterr()

--- a/tests/validate_env_test.py
+++ b/tests/validate_env_test.py
@@ -42,12 +42,9 @@ def test_validate_env_wrong_external_deps(mocker,):
     Test that validate env correctly handles invalid data for external dependencies.
     '''
     unused_env_for_arg = os.path.join(test_dir, 'test-env-invalid1.yaml')
-    env_file =b'''
-packages:
-    - feedstock : test1
-external_dependencies: ext_dep
-'''
-    mocker.patch('builtins.open', mocker.mock_open(read_data=env_file))
+    env_file = { 'packages' : [{ 'feedstock' : 'test1' }], 'external_dependencies' : 'ext_dep' }
+    mocker.patch('conda_utils.render_yaml', return_value=env_file)
+
     with pytest.raises(OpenCEError) as exc:
         open_ce._main(["validate", validate_env.COMMAND, unused_env_for_arg])
     assert "ext_dep is not of expected type <class 'list'>" in str(exc.value)
@@ -57,13 +54,9 @@ def test_validate_env_dict_for_external_deps(mocker,):
     Test that validate env correctly handles erroneously passing a dict for external dependencies.
     '''
     unused_env_for_arg = os.path.join(test_dir, 'test-env-invalid1.yaml')
-    env_file =b'''
-packages:
-    - feedstock : test1
-external_dependencies:
-    - feedstock : ext_dep
-'''
-    mocker.patch('builtins.open', mocker.mock_open(read_data=env_file))
+    env_file = { 'packages' : [{ 'feedstock' : 'test1' }], 'external_dependencies' : [{ 'feedstock' : 'ext_dep'}] }
+    mocker.patch('conda_utils.render_yaml', return_value=env_file)
+
     with pytest.raises(OpenCEError) as exc:
         open_ce._main(["validate", validate_env.COMMAND, unused_env_for_arg])
     assert "{'feedstock': 'ext_dep'} is not of expected type <class 'str'>" in str(exc.value)


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #154 .

This PR adds a `render_yaml` function that can be used when loading Open-CE configuration files. This will enable jinja within those files.

It also adds a string to the generated conda environment files that says what variants were set for that environment. This allows the test_feedstock function to know the variants.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
