### PR TITLE
Use the build string as key for BuildCommand

### DIFF
--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -101,7 +101,7 @@ def test_build_env(mocker):
     mocker.patch( # This ensures that 'package21' is not built when the python version is 2.0.
         'build_feedstock.build_feedstock_from_command',
         side_effect=(lambda x, *args, **kwargs: buildTracker.validate_build_feedstock(x, package_deps,
-                     conditions=[(lambda command: command.python == utils.DEFAULT_PYTHON_VERS), 
+                     conditions=[(lambda command: command.python == py_version), 
                                  (lambda command: command.recipe != "package21-feedstock")]))
     )
 
@@ -127,7 +127,7 @@ def test_build_env(mocker):
     mocker.patch(
         'build_feedstock.build_feedstock_from_command',
         side_effect=(lambda x, *args, **kwargs: buildTracker.validate_build_feedstock(x, package_deps,
-                     conditions=[(lambda command: command.python == utils.DEFAULT_PYTHON_VERS)]))
+                     conditions=[(lambda command: command.python == py_version)]))
     )
 
     env_file = os.path.join(test_dir, 'test-env2.yaml')

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -54,7 +54,6 @@ def test_create_commands(mocker):
                                                         ['run_req1            1.3'],
                                                         ['host_req1            1.0', 'host_req2'],
                                                         ['test_req1'],
-                                                        '',
                                                         ['string1_1'])
     mocker.patch(
         'conda_build.api.render',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,7 +99,7 @@ class DirTracker(object):
         return self.current_dir
 
 def make_render_result(package_name, build_reqs=None, run_reqs=None, host_reqs=None, test_reqs=None,
-                          noarch=None, string=None):
+                          string=None):
     '''
     Creates a YAML string that is a mocked result of `conda_build.api.render`.
     '''
@@ -107,7 +107,6 @@ def make_render_result(package_name, build_reqs=None, run_reqs=None, host_reqs=N
     if not run_reqs: run_reqs = []
     if not host_reqs: host_reqs = []
     if not test_reqs: test_reqs = []
-    if not noarch: noarch = ''
     if not string: string = ''
 
     retval = [(Namespace(meta={


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

The CuDNN build was failing because the CUDA version variable in the BuildCommand was empty. This was caused by #152. This PR changes the `key` for a BuildCommand to be the `build_string` from the recipe. It will not modify the other variables within a BuildCommand.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
