### PR TITLE
Use the output folder as BuildCommand's equality key

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -27,7 +27,7 @@ class BuildCommand():
                  recipe,
                  repository,
                  packages,
-                 build_strings=None,
+                 output_files=None,
                  python=None,
                  build_type=None,
                  mpi_type=None,
@@ -41,7 +41,7 @@ class BuildCommand():
         self.recipe = recipe
         self.repository = repository
         self.packages = packages
-        self.build_strings = build_strings
+        self.output_files = output_files
         self.python = python
         self.build_type = build_type
         self.mpi_type = mpi_type
@@ -96,7 +96,7 @@ class BuildCommand():
 
 
     def __key(self):
-        return (self.recipe, self.build_strings)
+        return (self.recipe, self.output_files)
 
     def __hash__(self):
         return hash(self.__key())
@@ -129,7 +129,7 @@ def _create_commands(repository, recipes, variant_config_files, variants, channe
     for recipe in config_data.get('recipes', []):
         if recipes and not recipe.get('name') in recipes:
             continue
-        packages, run_deps, host_deps, build_deps, test_deps, string = _get_package_dependencies(
+        packages, run_deps, host_deps, build_deps, test_deps, output_files = _get_package_dependencies(
                                                                                          recipe.get('path'),
                                                                                          combined_config_files,
                                                                                          variants)
@@ -137,7 +137,7 @@ def _create_commands(repository, recipes, variant_config_files, variants, channe
         build_commands.append(BuildCommand(recipe=recipe.get('name', None),
                                     repository=repository,
                                     packages=packages,
-                                    build_strings=string,
+                                    output_files=output_files,
                                     python=variants['python'],
                                     build_type=variants['build_type'],
                                     mpi_type=variants['mpi_type'],
@@ -175,11 +175,11 @@ def _get_package_dependencies(path, variant_config_files, variants):
         run_deps.update(meta.meta['requirements'].get('run', []))
         host_deps.update(meta.meta['requirements'].get('host', []))
         build_deps.update(meta.meta['requirements'].get('build', []))
-        string = meta.meta['build'].get('string', [])
+        output_files = conda_utils.get_output_file_paths(meta, variants=variants)
         if 'test' in meta.meta:
             test_deps.update(meta.meta['test'].get('requires', []))
 
-    return packages, run_deps, host_deps, build_deps, test_deps, string
+    return packages, run_deps, host_deps, build_deps, test_deps, output_files
 
 def _add_build_command_dependencies(variant_build_commands, build_commands, start_index=0):
     """

--- a/open-ce/conda_utils.py
+++ b/open-ce/conda_utils.py
@@ -7,6 +7,7 @@ disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 *****************************************************************
 """
 import os
+import pathlib
 
 import utils
 
@@ -44,3 +45,21 @@ def render_yaml(path, variants=None, variant_config_files=None, schema=None, per
     if schema:
         utils.validate_dict_schema(metas, schema)
     return metas
+
+def get_output_file_paths(meta, variants):
+    """
+    Get the paths of all of the generated packages for a recipe.
+    """
+    config = get_or_merge_config(None)
+    config.verbose = False
+
+    out_files = conda_build.api.get_output_file_paths(meta, config=config, variants=variants)
+
+    # Only return the package name and the parent directory. This will show where within the output
+    # directory the package should be.
+    result = []
+    for out_file in out_files:
+        path = pathlib.PurePath(out_file)
+        result.append(os.path.join(path.parent.name, path.name))
+
+    return result

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -61,6 +61,10 @@ def test_create_commands(mocker):
         return_value=render_result
     )
     mocker.patch(
+        'conda_build.api.get_output_file_paths',
+         return_value=['/output/path/linux/horovod.tar.gz']
+    )
+    mocker.patch(
         'os.chdir',
         side_effect=(lambda x: dir_tracker.validate_chdir(x, expected_dirs=["/test/my_repo", # First the working directory should be changed to the arg.
                                                                            "/test/starting_dir"])) # And then changed back to the starting directory.
@@ -396,6 +400,7 @@ def test_build_tree_duplicates():
     initial_build_commands = [build_tree.BuildCommand("recipe1",
                                                     "repo1",
                                                     ["package1a"],
+                                                    output_files=["linux/package1a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cuda",
                                                     mpi_type="openmpi",
@@ -407,6 +412,7 @@ def test_build_tree_duplicates():
                               build_tree.BuildCommand("recipe2",
                                                     "repo2",
                                                     ["package2a"],
+                                                    output_files=["linux/package2a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cuda",
                                                     mpi_type="openmpi",
@@ -419,6 +425,7 @@ def test_build_tree_duplicates():
     duplicate_build_commands = [build_tree.BuildCommand("recipe2",
                                                     "repo2",
                                                     ["package2a"],
+                                                    output_files=["linux/package2a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cuda",
                                                     mpi_type="openmpi",
@@ -431,6 +438,7 @@ def test_build_tree_duplicates():
                                 build_tree.BuildCommand("recipe1",
                                                     "repo1",
                                                     ["package1a"],
+                                                    output_files=["linux/package1a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cuda",
                                                     mpi_type="openmpi",
@@ -443,6 +451,7 @@ def test_build_tree_duplicates():
                                 build_tree.BuildCommand("recipe3",
                                                     "repo3",
                                                     ["package3a"],
+                                                    output_files=["linux/package3a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cpu",
                                                     mpi_type="openmpi",
@@ -454,6 +463,7 @@ def test_build_tree_duplicates():
     additional_build_commands = [build_tree.BuildCommand("recipe4",
                                                     "repo4",
                                                     ["package4a"],
+                                                    output_files=["linux/package4a.tar.gz"],
                                                     python="2.6",
                                                     build_type="cpu",
                                                     mpi_type="openmpi",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -133,3 +133,6 @@ def mock_renderer(path, package_deps):
     '''
     package = os.path.basename(path)[:-10]
     return make_render_result(package, package_deps[package])
+
+def mock_get_output_file_paths(meta):
+    return [meta.meta['package']['name'] + meta.meta['build']['string']]

--- a/tests/validate_config_test.py
+++ b/tests/validate_config_test.py
@@ -63,6 +63,11 @@ def test_validate_config(mocker):
         'conda_build.api.render',
         side_effect=(lambda path, *args, **kwargs: helpers.mock_renderer(os.getcwd(), package_deps))
     )
+    mocker.patch(
+        'conda_build.api.get_output_file_paths',
+        side_effect=(lambda meta, *args, **kwargs: helpers.mock_get_output_file_paths(meta))
+    )
+
     env_file = os.path.join(test_dir, 'test-env2.yaml')
     open_ce._main(["validate", validate_config.COMMAND, "--conda_build_config", "./conda_build_config.yaml", env_file, "--python_versions", "3.6", "--build_types", "cuda"])
 
@@ -109,6 +114,11 @@ def test_validate_negative(mocker):
         'conda_build.api.render',
         side_effect=(lambda path, *args, **kwargs: helpers.mock_renderer(os.getcwd(), package_deps))
     )
+    mocker.patch(
+        'conda_build.api.get_output_file_paths',
+        side_effect=(lambda meta, *args, **kwargs: helpers.mock_get_output_file_paths(meta))
+    )
+
     env_file = os.path.join(test_dir, 'test-env2.yaml')
     with pytest.raises(OpenCEError) as err:
         open_ce._main(["validate", validate_config.COMMAND, "--conda_build_config", "./conda_build_config.yaml", env_file, "--python_versions", "3.6", "--build_types", "cuda"])


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

There is still a problem with using the build string as the equality key for BuildCommand. Some recipes are modifying the actual package name based on the provided variants, not just the build string. In order to really check that two BuildCommands are equivalent we will now check the entire output file name, which can be obtained from conda-build's API.

Now that we have that information, we can also skip builds that have already been previously built as well.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
