### PR TITLE
Add variants to conda build config data structure

### DIFF
--- a/open-ce/build_feedstock.py
+++ b/open-ce/build_feedstock.py
@@ -113,8 +113,9 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments
             if recipes_to_build and recipe['name'] not in recipes_to_build:
                 continue
 
-            config = get_or_merge_config(None)
+            config = get_or_merge_config(None, variant=variant)
             config.skip_existing = True
+            config.prefix_length = 225
             config.output_folder = output_folder
             config.variant_config_files = [conda_build_config]
 
@@ -128,7 +129,7 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments
 
             try:
                 conda_build.api.build(os.path.join(os.getcwd(), recipe['path']),
-                               config=config, variants=variant)
+                               config=config)
             except Exception as exc: # pylint: disable=broad-except
                 traceback.print_exc()
                 raise OpenCEError(Error.BUILD_RECIPE,

--- a/open-ce/conda_utils.py
+++ b/open-ce/conda_utils.py
@@ -24,14 +24,13 @@ def render_yaml(path, variants=None, variant_config_files=None, schema=None, per
     Call conda-build's render tool to get a list of dictionaries of the
     rendered YAML file for each variant that will be built.
     """
-    config = get_or_merge_config(None)
+    config = get_or_merge_config(None, variant=variants)
     config.variant_config_files = variant_config_files
     config.verbose = False
 
     if not os.path.isfile(path):
         metas = conda_build.api.render(path,
                                        config=config,
-                                       variants=variants,
                                        bypass_env_check=True,
                                        finalize=False)
     else:
@@ -40,7 +39,6 @@ def render_yaml(path, variants=None, variant_config_files=None, schema=None, per
         # The absolute path is needed because MetaData seems to do some caching based on file name.
         metas = conda_build.metadata.MetaData(
                             os.path.abspath(path),
-                            variant=variants,
                             config=config).get_rendered_recipe_text(permit_undefined_jinja=permit_undefined_jinja)
     if schema:
         utils.validate_dict_schema(metas, schema)
@@ -50,10 +48,10 @@ def get_output_file_paths(meta, variants):
     """
     Get the paths of all of the generated packages for a recipe.
     """
-    config = get_or_merge_config(None)
+    config = get_or_merge_config(None, variant=variants)
     config.verbose = False
 
-    out_files = conda_build.api.get_output_file_paths(meta, config=config, variants=variants)
+    out_files = conda_build.api.get_output_file_paths(meta, config=config)
 
     # Only return the package name and the parent directory. This will show where within the output
     # directory the package should be.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -72,7 +72,7 @@ def validate_conda_build_args(recipe, expect_recipe=None, expect_config=None, ex
             assert hasattr(config, term)
             assert getattr(config, term) == value
     if expect_variants:
-        variants = kwargs['variants']
+        variants = kwargs['config'].variant
         for term, value in expect_variants.items():
             assert term in variants
             assert variants.get(term) == value


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This PR addresses two issues:
1) It allows for the Open-CE specific variants (python_version, build_type, cudatoolkit, etc.) to be used within line selectors in the conda_build_config.py files. It does this by passing variants in to the conda_build functions through the `config` data structure instead of as separate arguments.
2) It reduces the prefix length. The larger prefix length was seen to cause issues within some tests on RHEL 8.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
