### PR TITLE
Patches should be relative to Open-CE environment files

### DIFF
--- a/envs/lightgbm-env.yaml
+++ b/envs/lightgbm-env.yaml
@@ -4,4 +4,4 @@ packages:
   - feedstock : https://github.com/conda-forge/cmake-feedstock
     git_tag : 26e3ecb4156c14d90a66fd1433d52a1d7e27946d
     patches :
-      - ./feedstock-patches/cmake/0001-Fix-test.patch
+      - ../feedstock-patches/cmake/0001-Fix-test.patch

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -397,12 +397,13 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             patches = package.get(env_config.Key.patches.name, []) if package else []
             if len(patches) > 0:
                 os.chdir(repo_dir)
-                open_ce_path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
                 for patch in patches:
                     if os.path.isabs(patch) and os.path.exists(patch):
                         patch_file = patch
                     else:
-                        patch_file = os.path.join(open_ce_path, patch)
+                        # Look for patch relative to where the Open-CE environment file is
+                        patch_file = os.path.join(os.path.dirname(env_config_data.get(
+                                                  env_config.Key.opence_env_file_path)), patch)
                     patch_apply_cmd = "git apply {}".format(patch_file)
                     print("Patch apply command: ", patch_apply_cmd)
                     patch_apply_res = os.system(patch_apply_cmd)

--- a/open-ce/env_config.py
+++ b/open-ce/env_config.py
@@ -28,6 +28,7 @@ class Key(Enum):
     recipes = auto()
     external_dependencies = auto()
     patches = auto()
+    opence_env_file_path = auto()
 
 _PACKAGE_SCHEMA ={
     Key.feedstock.name: utils.make_schema_type(str, True),
@@ -51,6 +52,7 @@ def _validate_config_file(env_file, variants):
         meta_obj = conda_utils.render_yaml(env_file, variants=variants, schema=_ENV_CONFIG_SCHEMA)
         if not (Key.packages.name in meta_obj.keys() or Key.imported_envs.name in meta_obj.keys()):
             raise OpenCEError(Error.CONFIG_CONTENT)
+        meta_obj[Key.opence_env_file_path] = env_file
         return meta_obj
     except (Exception, SystemExit) as exc: #pylint: disable=broad-except
         raise OpenCEError(Error.ERROR, "Error in {}:\n  {}".format(env_file, str(exc))) from exc


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Using `__file__` to determine where relative paths for Open-CE environmet patches are was causing issues. This PR makes  the paths be relative to the actual Open-CE environment file that is referencing the patch.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
