### PR TITLE
Fix output_files error

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -177,12 +177,13 @@ def _get_package_dependencies(path, variant_config_files, variants):
     host_deps = set()
     build_deps = set()
     test_deps = set()
+    output_files = []
     for meta,_,_ in metas:
         packages.add(meta.meta['package']['name'])
         run_deps.update(meta.meta['requirements'].get('run', []))
         host_deps.update(meta.meta['requirements'].get('host', []))
         build_deps.update(meta.meta['requirements'].get('build', []))
-        output_files = conda_utils.get_output_file_paths(meta, variants=variants)
+        output_files += conda_utils.get_output_file_paths(meta, variants=variants)
         if 'test' in meta.meta:
             test_deps.update(meta.meta['test'].get('requires', []))
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes issue where the output_file of a build_command was always the last package in recipes with multiple packages.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
