### PR TITLE
Enable the FEEDSTOCK_DIR environment variable in tests

### DIFF
--- a/doc/README.open_ce_test.md
+++ b/doc/README.open_ce_test.md
@@ -32,6 +32,14 @@ This example will:
 1. If running within a CUDA environment, run the bash instructions specified by `command` in "CUDA Test" within a new bash shell that activates the conda environment from step 1.
 1. Removes the conda environment created in step 1.
 
+#### Open-CE Test File Environment Variables
+
+The following environment variables can be referenced within the command section of an Open-CE test:
+
+| Environment Variable | Description |
+| -------------------- | ----------- |
+| FEEDSTOCK_DIR        | Path of the feedstock directory containing the test |
+
 ### Test Labels
 
 Labels can be added to tests using jinja. Labels can be activated using the `--test_labels` argument to the `open-ce test` tools. Below is an example of a test file that only runs the second test if the `long` label is activated.

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -83,8 +83,7 @@ class TestCommand():
         output += "CONDA_BIN=$(dirname $(which conda))\n"
         output += "source ${CONDA_BIN}/../etc/profile.d/conda.sh\n"
         output += "conda activate " + self.conda_env + "\n"
-        if self.feedstock_dir:
-            output += "export FEEDSTOCK_DIR=" + self.feedstock_dir + "\n"
+        output += "export FEEDSTOCK_DIR=" + self.feedstock_dir + "\n"
         output += self.bash_command + "\n"
 
         return output

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -53,13 +53,15 @@ class TestCommand():
         working_dir (str): Working directory to be used when executing the bash command.
     """
     #pylint: disable=too-many-arguments
-    def __init__(self, name, conda_env=None, bash_command="", create_env=False, clean_env=False, working_dir=os.getcwd()):
+    def __init__(self, name, conda_env=None, bash_command="",
+                 create_env=False, clean_env=False, working_dir=os.getcwd()):
         self.bash_command = bash_command
         self.conda_env = conda_env
         self.name = name
         self.create_env = create_env
         self.clean_env = clean_env
         self.working_dir = working_dir
+        self.feedstock_dir = os.getcwd()
 
     def get_test_command(self, conda_env_file=None):
         """"
@@ -81,6 +83,8 @@ class TestCommand():
         output += "CONDA_BIN=$(dirname $(which conda))\n"
         output += "source ${CONDA_BIN}/../etc/profile.d/conda.sh\n"
         output += "conda activate " + self.conda_env + "\n"
+        if self.feedstock_dir:
+            output += "export FEEDSTOCK_DIR=" + self.feedstock_dir + "\n"
         output += self.bash_command + "\n"
 
         return output


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Enables the FEEDSTOCK_DIR environment variable to be referenced from within an Open-CE test file. This will enable tests to use files that are stored within the feedstock.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
