### PR TITLE
Disable Openmpi for cpu builds

### DIFF
--- a/envs/lightgbm-env.yaml
+++ b/envs/lightgbm-env.yaml
@@ -1,6 +1,6 @@
 packages:
   - feedstock : LightGBM
-  - feedstock : openmpi          #[mpi_type == 'openmpi']
+  - feedstock : openmpi          #[mpi_type == 'openmpi' and build_type == 'cuda']
   - feedstock : https://github.com/conda-forge/cmake-feedstock
     git_tag : 26e3ecb4156c14d90a66fd1433d52a1d7e27946d
     patches :


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Disable openmpi to be built for cpu builds via lightgbm environment file.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
