### PR TITLE
Add rsync to the UBI 8 images

### DIFF
--- a/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
+++ b/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
@@ -18,6 +18,7 @@ RUN export ARCH="$(uname -m)" && \
     yum repolist && yum install -y \
     sudo \
     bzip2 \
+    rsync \
     git \
     patch && \
     # Create CICD Group

--- a/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
+++ b/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
@@ -18,6 +18,7 @@ RUN export ARCH="$(uname -m)" && \
     yum repolist && yum install -y \
     sudo \
     bzip2 \
+    rsync \
     git \
     patch && \
     # Create CICD Group


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Add rsync to the UBI 8 images. For some reason, the UBI 8 images don't have rsync installed, even though the UBI 7 images do. This PR will manually install `rsync` into the UBI 8 images.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
