### PR TITLE
Set the rhash version in cmake recipe

### DIFF
--- a/envs/lightgbm-env.yaml
+++ b/envs/lightgbm-env.yaml
@@ -5,4 +5,5 @@ packages:
     git_tag : 26e3ecb4156c14d90a66fd1433d52a1d7e27946d
     patches :
       - ../feedstock-patches/cmake/0001-Fix-test.patch
+      - ../feedstock-patches/cmake/0002-set-rhash-version.patch
     runtime_package : False

--- a/feedstock-patches/cmake/0002-set-rhash-version.patch
+++ b/feedstock-patches/cmake/0002-set-rhash-version.patch
@@ -1,0 +1,22 @@
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index dd20d84..d37d3e2 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -28,7 +28,7 @@ requirements:
+     - xz              # [unix]
+     - zlib            # [unix]
+     - libuv           # [unix]
+-    - rhash           # [unix]
++    - rhash 1.4.0          # [unix]
+ 
+   run:
+     - bzip2           # [unix]
+@@ -38,7 +38,7 @@ requirements:
+     - xz              # [unix]
+     - zlib            # [unix]
+     - libuv           # [unix]
+-    - rhash           # [unix]
++    - rhash 1.4.0          # [unix]
+     - vs2015_runtime  # [win]
+   
+   run_constrained:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #246 .

The most recent version of Anaconda's rhash package seems to be broken. This PR pins rhash to version 1.4.0 in the cmake recipe.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
