### PR TITLE
Set ffmpeg pin to 4.2.0

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -50,7 +50,7 @@ dm_tree:
 eigen:
   - 3.3.7
 ffmpeg:
-  - 4.2
+  - 4.2.0
 flatbuffers:
   - 1.12.*
 freetype:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Sets ffmpeg to 4.2.0. This is done because Anaconda's version of ffmpeg 4.2.2 is pulling in the x264 library.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
