### PR TITLE
Add the recipe_path field to open-ce environment files

### DIFF
--- a/doc/README.yaml.md
+++ b/doc/README.yaml.md
@@ -33,16 +33,17 @@ serving a different purpose. All are used to define key-value pairs as used in a
 YAML file format. The keywords recognized for Open-CE environments include the
 following:
 ```
-packages:      # The environment package name
-  - feedstock: # Defines each feedstock comprising the environment
-  - channels:  # Defines a channel location for obtaining dependencies
-  - git_tag:   # Defines a specific git tag to use for this feedstock
-  - recipes:   # Sets name and path of recipe location(s)
-  - patches:   # Specifies list of patches to be applied to this feedstock
+packages:            # The environment package name
+  - feedstock:       # Defines each feedstock comprising the environment
+  - channels:        # Defines a channel location for obtaining dependencies
+  - git_tag:         # Defines a specific git tag to use for this feedstock
+  - recipe_path:     # Specifies the path to the recipe within this feedstock
+  - recipes:         # Sets name and path of recipe location(s)
+  - patches:         # Specifies list of patches to be applied to this feedstock
   - runtime_package: # Specifies if the package is needed at runtime for the main frameworks to install
-imported_envs: # Used to import content of one env file into another
-channels:      # Defines a channel location for obtaining dependencies
-git_tag_for_env: # Specify a git tag to use across all packages in environment
+imported_envs:       # Used to import content of one env file into another
+channels:            # Defines a channel location for obtaining dependencies
+git_tag_for_env:     # Specify a git tag to use across all packages in environment
 ```
 
 Most of these are optional. At a minimum, the environment files will define one
@@ -68,22 +69,38 @@ be built if the `build_type` is set to `cuda` when executing the `build_env.py`
 script, so it is considered an optional dependency that you may want to include
 if your runtime environment has CUDA available.
 
+The other keywords that optionally can be used as part of the `packages` stanza
+include `git_tag`, `recipe_path`, `patches`, `channels`, `runtime_package` and
+`recipes`.
+
 ### git_tag
 
-The other keywords that optionally can be used as part of the `packages` stanza
-include `git_tag`, `patches`, `channels`, `runtime_package` and `recipes`. By default,
-the git tag will be the current (i.e. main or master) branch of the specified source
-tree, such that you don't need to include this keyword unless you want to explicitly
+By default, the git tag will be the current (i.e. main or master) branch of the specified
+source tree, such that you don't need to include this keyword unless you want to explicitly
 override it to fetch a different version. To do this, you will simply specify the version
 value or the hexadecimal git tag value that you want to obtain during the build.
+
 An example might look something like this:
 ```
 packages:
   - feedstock: dummy_example
     git_tag: v1.0.0
 ```
-This might be useful if there is a new default version, but you want to
+This can be useful if there is a new default version, but you want to
 specifically build an older tagged version.
+
+### recipe_path
+
+By default, the recipe_path will be `recipe`. This field specifies the path within the
+feedstock containing the conda recipe.
+
+An example might look something like this:
+
+```
+packages:
+  - feedstock: dummy_example
+    recipe_path: my_recipe_path
+``` 
 
 ### runtime_package
 

--- a/open-ce/build_feedstock.py
+++ b/open-ce/build_feedstock.py
@@ -44,7 +44,7 @@ def get_conda_build_config():
     recipe_conda_build_config = os.path.join(os.getcwd(), "config", "conda_build_config.yaml")
     return recipe_conda_build_config if os.path.exists(recipe_conda_build_config) else None
 
-def load_package_config(config_file=None, variants=None):
+def load_package_config(config_file=None, variants=None, recipe_path=None):
     '''
     Check for a config file. If the user does not provide a recipe config
     file as an argument, it will be assumed that there is only one
@@ -53,7 +53,10 @@ def load_package_config(config_file=None, variants=None):
     # pylint: disable=import-outside-toplevel
     import conda_utils
 
-    if not config_file and not os.path.exists(utils.DEFAULT_RECIPE_CONFIG_FILE):
+    if recipe_path:
+        recipe_name = os.path.basename(os.getcwd())
+        build_config_data = {'recipes':[{'name':recipe_name, 'path':recipe_path}]}
+    elif not config_file and not os.path.exists(utils.DEFAULT_RECIPE_CONFIG_FILE):
         recipe_name = os.path.basename(os.getcwd())
         build_config_data = {'recipes':[{'name':recipe_name, 'path':'recipe'}]}
     else:
@@ -116,7 +119,7 @@ def build_feedstock_from_command(command, # pylint: disable=too-many-arguments, 
     recipes_to_build = inputs.parse_arg_list(command.recipe)
 
     for variant in utils.make_variants(command.python, command.build_type, command.mpi_type, command.cudatoolkit):
-        build_config_data, recipe_config_file  = load_package_config(recipe_config_file, variant)
+        build_config_data, recipe_config_file  = load_package_config(recipe_config_file, variant, command.recipe_path)
 
         # Build each recipe
         if build_config_data['recipes'] is None:

--- a/open-ce/env_config.py
+++ b/open-ce/env_config.py
@@ -36,6 +36,7 @@ class Key(Enum):
     patches = auto()
     opence_env_file_path = auto()
     runtime_package = auto()
+    recipe_path = auto()
 
 _PACKAGE_SCHEMA ={
     Key.feedstock.name: utils.make_schema_type(str, True),
@@ -43,7 +44,8 @@ _PACKAGE_SCHEMA ={
     Key.recipes.name: utils.make_schema_type([str]),
     Key.channels.name: utils.make_schema_type([str]),
     Key.patches.name: utils.make_schema_type([str]),
-    Key.runtime_package.name: utils.make_schema_type(bool)
+    Key.runtime_package.name: utils.make_schema_type(bool),
+    Key.recipe_path.name: utils.make_schema_type(str)
 }
 
 _ENV_CONFIG_SCHEMA = {

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -59,7 +59,7 @@ def test_create_commands(mocker):
     )
     render_result=helpers.make_render_result("horovod", ['build_req1', 'build_req2            1.2'],
                                                         ['run_req1            1.3'],
-                                                        ['host_req1            1.0', 'host_req2'],
+                                                        ['Host_req1            1.0', 'host_req2'],
                                                         ['test_req1'],
                                                         ['string1_1'])
     mocker.patch(
@@ -76,8 +76,9 @@ def test_create_commands(mocker):
                                                                            "/test/starting_dir"])) # And then changed back to the starting directory.
     )
 
-    build_commands, _ = build_tree._create_commands("/test/my_repo", "True", None, "master", {'python' : '3.6', 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, [], [])
+    build_commands, _ = build_tree._create_commands("/test/my_repo", "True", "my_recipe_path", None, "master", {'python' : '3.6', 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, [], [])
     assert build_commands[0].packages == {'horovod'}
+    assert build_commands[0].recipe_path == "my_recipe_path"
     for dep in {'build_req1', 'build_req2            1.2'}:
         assert dep in build_commands[0].build_dependencies
     for dep in {'run_req1            1.3'}:

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -329,6 +329,23 @@ def test_check_runtime_package_field():
                 if package.get(env_config.Key.feedstock.name) == "package222":
                     assert package.get(env_config.Key.runtime_package.name) == False
 
+def test_check_recipe_path_package_field():
+    '''
+    Test for `runtime_package` field
+    '''
+    env_file = os.path.join(test_dir, 'test-env1.yaml')
+
+    possible_variants = utils.make_variants("3.6", "cpu", "openmpi", "10.2")
+    for variant in possible_variants:
+
+        # test-env1.yaml has defined "recipe_path" as "package11_recipe_path" for "package11".
+        env_config_data_list = env_config.load_env_config_files([env_file], variant)
+        for env_config_data in env_config_data_list:
+            packages = env_config_data.get(env_config.Key.packages.name, [])
+            for package in packages:
+                if package.get(env_config.Key.feedstock.name) == "package11":
+                    assert package.get(env_config.Key.recipe_path.name) == "package11_recipe_path"
+
 sample_build_commands = [build_tree.BuildCommand("recipe1",
                                     "repo1",
                                     ["package1a", "package1b"],

--- a/tests/test-env1.yaml
+++ b/tests/test-env1.yaml
@@ -19,6 +19,7 @@ channels:
 packages:
     - feedstock : package11
       git_tag : package11-bug-fix
+      recipe_path: package11_recipe_path
     - feedstock : https://myhost.com/myorg/package12-feedstock
     - feedstock : http://myhost.com/myorg/package13-feedstock.git
     - feedstock : git@myhost/myorg/package14-feedstock.git


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This PR does two things that make it easier to build external feedstocks.

1. Adds the `recipe_path` field to a `package` within an Open-CE Environment file. This allows for external feedstocks that don't keep their recipes within a directory called `recipe`.
2. Makes all dependencies lower-case internally. I found some recipes that had packages with upper-case letters. `conda` treats these the same as if they were all lower-case, so the Open-CE tools should do the same.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
