### PR TITLE
README update for CUDA_HOME restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ test/
 Currently CUDA 10.2 and 11.0 are supported by the recipes in Open-CE. Please see [`doc/README.cuda_support.md`](doc/README.cuda_support.md) for details on setting
 up a proper build enviornment for CUDA support.
 
-Open-CE expects the `CUDA_HOME` environment variable to be set to the location of the CUDA installation.
+Open-CE expects the `CUDA_HOME` environment variable to be set to the location of the CUDA installation. Note that not all recipes work when `CUDA_HOME` references a non-standard CUDA installation location. Reference the [cuda README](doc/README.cuda_support.md) for more information.
 
 When building packages that use CUDA, a tar package of TensorRT for the intended CUDA version will need to be [downloaded](https://developer.nvidia.com/nvidia-tensorrt-7x-download) ahead of time. The downloaded file should be placed in a new local directory called `local_files`. The [cuda README](doc/README.cuda_support.md) has more information.
 

--- a/doc/README.cuda_support.md
+++ b/doc/README.cuda_support.md
@@ -7,6 +7,16 @@ the builds are taking place. This can be accomplished in two ways (see below).
 **In all cases, the `CUDA_HOME` environment variable must be set to the base
 directory where CUDA has been installed.**
 
+The standard CUDA installation location is in `/usr/local/cuda` which is typically
+a symbolic link to either `/usr/local/cuda-10.2` or `/usr/local/cuda-11.0`. Most of
+the code bases that are built in Open-CE are flexible enough to tolerate CUDA
+installations in non-standard locations, but not all of them. The reference table below
+includes the recipes that will not work when CUDA is installed elsewhere.
+
+| CUDA_HOME restrictions |
+|-----------------|
+| tensorflow-serving |
+
 ## Bare metal builds
 
 If you are using Open-CE on a bare metal system. Install the appropriate version


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Update the documentation to raise awareness that the TensorFlow-Serving recipe requires CUDA_HOME to be set to a standard CUDA installation location.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
