### PR TITLE
Improve test feedstock

### DIFF
--- a/open-ce/build_env.py
+++ b/open-ce/build_env.py
@@ -42,7 +42,7 @@ ARGUMENTS = [Argument.CONDA_BUILD_CONFIG, Argument.OUTPUT_FOLDER,
              Argument.GIT_LOCATION, Argument.GIT_TAG_FOR_ENV,
              Argument.TEST_LABELS]
 
-def _run_tests(build_tree, conda_env_files):
+def _run_tests(build_tree, test_labels, conda_env_files):
     """
     Run through all of the tests within a build tree for the given conda environment files.
 
@@ -54,12 +54,14 @@ def _run_tests(build_tree, conda_env_files):
     failed_tests = []
     # Run test commands for each conda environment that was generated
     for variant_string, conda_env_file in conda_env_files.items():
-        test_commands = build_tree.get_test_commands(variant_string)
-        if test_commands:
+        test_feedstocks = build_tree.get_test_feedstocks(variant_string)
+        if test_feedstocks:
             print("\n*** Running tests within the " + os.path.basename(conda_env_file) + " conda environment ***\n")
-        for feedstock, feedstock_test_commands in test_commands.items():
+        for feedstock in test_feedstocks:
             print("Running tests for " + feedstock)
-            failed_tests += test_feedstock.run_test_commands(conda_env_file, feedstock_test_commands)
+            failed_tests += test_feedstock.test_feedstock(conda_env_file,
+                                                          test_labels=test_labels,
+                                                          working_directory=feedstock)
 
     test_feedstock.display_failed_tests(failed_tests)
     if failed_tests:
@@ -105,8 +107,7 @@ def build_env(args):
                                channels=args.channels_list,
                                git_location=args.git_location,
                                git_tag_for_env=args.git_tag_for_env,
-                               conda_build_config=args.conda_build_config,
-                               test_labels=inputs.parse_arg_list(args.test_labels))
+                               conda_build_config=args.conda_build_config)
 
     # Generate conda environment files
     conda_env_files = build_tree.write_conda_env_files(output_folder=os.path.abspath(args.output_folder),
@@ -130,6 +131,6 @@ def build_env(args):
                 print("Skipping build of " + build_command.recipe + " because it already exists")
 
     if args.run_tests:
-        _run_tests(build_tree, conda_env_files)
+        _run_tests(build_tree, inputs.parse_arg_list(args.test_labels), conda_env_files)
 
 ENTRY_FUNCTION = build_env

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -167,8 +167,6 @@ def _create_commands(repository, runtime_package, recipe_path,
                                     test_dependencies=test_deps,
                                     channels=channels))
 
-    variant_copy = dict(variants)
-
     os.chdir(saved_working_directory)
     return build_commands
 

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -23,7 +23,6 @@ import validate_config
 import build_feedstock
 from errors import OpenCEError, Error
 from conda_env_file_generator import CondaEnvFileGenerator
-import test_feedstock
 
 
 class BuildCommand():
@@ -125,7 +124,7 @@ def _make_hash(to_hash):
 
 #pylint: disable=too-many-locals,too-many-arguments
 def _create_commands(repository, runtime_package, recipe_path,
-                     recipes, variant_config_files, variants, channels, test_labels):
+                     recipes, variant_config_files, variants, channels):
     """
     Returns:
         A list of BuildCommands for each recipe within a repository.
@@ -169,13 +168,9 @@ def _create_commands(repository, runtime_package, recipe_path,
                                     channels=channels))
 
     variant_copy = dict(variants)
-    if test_labels:
-        for test_label in test_labels:
-            variant_copy[test_label] = True
-    test_commands = test_feedstock.gen_test_commands(variants=variant_copy)
 
     os.chdir(saved_working_directory)
-    return build_commands, test_commands
+    return build_commands
 
 def _clean_dep(dep):
     return dep.lower()
@@ -289,8 +284,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                  channels=None,
                  git_location=utils.DEFAULT_GIT_LOCATION,
                  git_tag_for_env=utils.DEFAULT_GIT_TAG,
-                 conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG,
-                 test_labels=None):
+                 conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG):
 
         self._env_config_files = env_config_files
         self._repository_folder = repository_folder
@@ -300,8 +294,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         self._conda_build_config = conda_build_config
         self._external_dependencies = dict()
         self._conda_env_files = dict()
-        self._test_commands = dict()
-        self._test_labels = test_labels
+        self._test_feedstocks = dict()
 
         # Create a dependency tree that includes recipes for every combination
         # of variants.
@@ -309,13 +302,13 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         self.build_commands = []
         for variant in self._possible_variants:
             try:
-                build_commands, external_deps, test_commands = self._create_all_commands(variant)
+                build_commands, external_deps, test_feedstocks = self._create_all_commands(variant)
             except OpenCEError as exc:
                 raise OpenCEError(Error.CREATE_BUILD_TREE, exc.msg) from exc
             variant_string = utils.variant_string(variant["python"], variant["build_type"],
                                                   variant["mpi_type"], variant["cudatoolkit"])
             self._external_dependencies[variant_string] = external_deps
-            self._test_commands[variant_string] = test_commands
+            self._test_feedstocks[variant_string] = test_feedstocks
             validate_config.validate_build_tree(build_commands, external_deps)
 
             installable_packages = get_installable_packages(build_commands, external_deps)
@@ -364,7 +357,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         packages_seen = set()
         build_commands = []
         external_deps = []
-        test_commands = dict()
+        test_feedstocks = []
         # Create recipe dictionaries for each repository in the environment file
         for env_config_data in env_config_data_list:
             channels = self._channels + env_config_data.get(env_config.Key.channels.name, [])
@@ -377,18 +370,16 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
                 repository, repo_dir = self._get_repo(env_config_data, package)
                 runtime_package = package.get(env_config.Key.runtime_package.name, True)
-                repo_build_commands, repo_test_commands = _create_commands(repo_dir,
-                                                            runtime_package,
-                                                            package.get(env_config.Key.recipe_path.name),
-                                                            package.get(env_config.Key.recipes.name),
-                                                            [os.path.abspath(self._conda_build_config)],
-                                                            variants,
-                                                            channels,
-                                                            self._test_labels)
+                repo_build_commands = _create_commands(repo_dir,
+                                                       runtime_package,
+                                                       package.get(env_config.Key.recipe_path.name),
+                                                       package.get(env_config.Key.recipes.name),
+                                                       [os.path.abspath(self._conda_build_config)],
+                                                       variants,
+                                                       channels)
 
                 build_commands += repo_build_commands
-                if repo_test_commands and not repository in self._test_commands:
-                    test_commands[repository] = repo_test_commands
+                test_feedstocks.append(repository)
 
                 packages_seen.add(_make_hash(package))
 
@@ -396,7 +387,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             if current_deps:
                 external_deps += current_deps
 
-        return build_commands, external_deps, test_commands
+        return build_commands, external_deps, test_feedstocks
 
     #pylint: disable=too-many-branches
     def _clone_repo(self, git_url, repo_dir, env_config_data, package):
@@ -497,11 +488,11 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
 
         return conda_env_files
 
-    def get_test_commands(self, variant_string):
+    def get_test_feedstocks(self, variant_string):
         """
-        Return a dictionary of test commands, where each key is the repository name.
+        Return a list of feedstocks to run tests on, for a given variant.
         """
-        return self._test_commands[variant_string]
+        return self._test_feedstocks[variant_string]
 
     def _detect_cycle(self, max_cycles=10):
         extract_build_tree = [x.build_command_dependencies for x in self.build_commands]

--- a/open-ce/inputs.py
+++ b/open-ce/inputs.py
@@ -130,7 +130,7 @@ class Argument(Enum):
     TEST_WORKING_DIRECTORY = (lambda parser: parser.add_argument(
                                         '--test_working_dir',
                                         type=str,
-                                        default="./",
+                                        default=utils.DEFAULT_TEST_WORKING_DIRECTORY,
                                         help="Directory where tests will be executed."))
 
     RECIPE_CONFIG_FILE = (lambda parser: parser.add_argument(

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -31,7 +31,8 @@ from errors import OpenCEError, Error
 
 COMMAND = 'feedstock'
 DESCRIPTION = 'Test a feedstock as part of Open-CE'
-ARGUMENTS = [Argument.CONDA_ENV_FILE, Argument.TEST_WORKING_DIRECTORY, Argument.TEST_LABELS]
+ARGUMENTS = [Argument.CONDA_ENV_FILE, Argument.TEST_WORKING_DIRECTORY, Argument.TEST_LABELS,
+             Argument.WORKING_DIRECTORY]
 
 @unique
 class Key(Enum):

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -245,27 +245,39 @@ def display_failed_tests(failed_tests):
     else:
         print("All tests passed!")
 
-def _test_feedstock(args):
-    conda_env_file = os.path.abspath(args.conda_env_file)
+def test_feedstock(conda_env_file, test_labels=None,
+                   test_working_dir=utils.DEFAULT_TEST_WORKING_DIRECTORY, working_directory=None):
+    saved_working_directory = None
+    if working_directory:
+        saved_working_directory = os.getcwd()
+        os.chdir(os.path.abspath(working_directory))
+
+    conda_env_file = os.path.abspath(conda_env_file)
     var_string = conda_env_file_generator.get_variant_string(conda_env_file)
     if var_string:
         variant_dict = utils.variant_string_to_dict(var_string)
     else:
         variant_dict = dict()
-    for test_label in inputs.parse_arg_list(args.test_labels):
+    for test_label in inputs.parse_arg_list(test_labels):
         variant_dict[test_label] = True
-    test_commands = gen_test_commands(working_dir=args.test_working_dir, variants=variant_dict)
+    test_commands = gen_test_commands(working_dir=test_working_dir, variants=variant_dict)
     failed_tests = run_test_commands(conda_env_file, test_commands)
-    display_failed_tests(failed_tests)
 
-    return len(failed_tests)
+    if saved_working_directory:
+        os.chdir(saved_working_directory)
 
-def test_feedstock(args):
+    return failed_tests
+
+def test_feedstock_entry(args):
     '''Entry Function'''
     if not args.conda_env_file:
         raise OpenCEError(Error.CONDA_ENV_FILE_REQUIRED)
-    test_failures = _test_feedstock(args)
+    test_failures = test_feedstock(args.conda_env_file,
+                                   args.test_labels,
+                                   args.test_working_dir,
+                                   args.working_directory)
     if test_failures:
-        raise OpenCEError(Error.FAILED_TESTS, test_failures)
+        display_failed_tests(test_failures)
+        raise OpenCEError(Error.FAILED_TESTS, len(test_failures))
 
-ENTRY_FUNCTION = test_feedstock
+ENTRY_FUNCTION = test_feedstock_entry

--- a/open-ce/test_feedstock.py
+++ b/open-ce/test_feedstock.py
@@ -248,6 +248,9 @@ def display_failed_tests(failed_tests):
 
 def test_feedstock(conda_env_file, test_labels=None,
                    test_working_dir=utils.DEFAULT_TEST_WORKING_DIRECTORY, working_directory=None):
+    """
+    Test a particular feedstock, provided by the working_directory argument.
+    """
     saved_working_directory = None
     if working_directory:
         saved_working_directory = os.getcwd()

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -41,6 +41,7 @@ DEFAULT_OUTPUT_FOLDER = "condabuild"
 DEFAULT_TEST_CONFIG_FILE = "tests/open-ce-tests.yaml"
 DEFAULT_GIT_TAG = None
 OPEN_CE_VARIANT = "open-ce-variant"
+DEFAULT_TEST_WORKING_DIRECTORY = "./"
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -315,26 +315,32 @@ def test_build_env_if_no_conda_build(mocker):
     with pytest.raises(OpenCEError):
         open_ce._main(arg_strings)
 
-def test_run_tests():
+def test_run_tests(mocker):
     '''
     Test that the _run_tests function works properly.
     '''
+    dirTracker = helpers.DirTracker()
     mock_build_tree = TestBuildTree([], "3.6", "cpu,cuda", "openmpi", "10.2")
+    mock_test_commands = [test_feedstock.TestCommand("Test1",
+                                                      conda_env="test-conda-env2.yaml",
+                                                      bash_command="echo Test1"),
+                          test_feedstock.TestCommand("Test2",
+                                                      conda_env="test-conda-env2.yaml",
+                                                      bash_command="[ 1 -eq 2 ]")]
 
+    mocker.patch("test_feedstock.gen_test_commands", return_value=mock_test_commands)
+    mocker.patch(
+        'os.chdir',
+        side_effect=dirTracker.validate_chdir
+    )
     conda_env_files = dict()
     mock_build_tree._test_commands = dict()
+
     for variant in mock_build_tree._possible_variants:
-        conda_env_files[str(variant)] = "conda_env_" + str(variant)
-        mock_build_tree._test_commands[str(variant)] = { "feedstock1" :
-                                                        [test_feedstock.TestCommand("Test1",
-                                                                                    conda_env=conda_env_files[str(variant)],
-                                                                                    bash_command="echo Test1"),
-                                                        test_feedstock.TestCommand("Test2",
-                                                                                    conda_env=conda_env_files[str(variant)],
-                                                                                    bash_command="[ 1 -eq 2 ]")]
-                                                       }
+        conda_env_files[str(variant)] = "tests/test-conda-env2.yaml"
+        mock_build_tree._test_feedstocks[str(variant)] = ["feedstock1"]
 
     # Note: All of the tests should fail, since there isn't a real conda environment to activate
     with pytest.raises(OpenCEError) as exc:
-        build_env._run_tests(mock_build_tree, conda_env_files)
+        build_env._run_tests(mock_build_tree, [], conda_env_files)
     assert "There were 4 test failures" in str(exc.value)

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -46,6 +46,7 @@ class TestBuildTree(build_tree.BuildTree):
         self._git_tag_for_env = git_tag_for_env
         self._conda_build_config = conda_build_config
         self._possible_variants = utils.make_variants(python_versions, build_types, mpi_types, cuda_versions)
+        self._test_feedstocks = dict()
 
 def test_create_commands(mocker):
     '''
@@ -76,7 +77,7 @@ def test_create_commands(mocker):
                                                                            "/test/starting_dir"])) # And then changed back to the starting directory.
     )
 
-    build_commands, _ = build_tree._create_commands("/test/my_repo", "True", "my_recipe_path", None, "master", {'python' : '3.6', 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, [], [])
+    build_commands = build_tree._create_commands("/test/my_repo", "True", "my_recipe_path", None, "master", {'python' : '3.6', 'build_type' : 'cuda', 'mpi_type' : 'openmpi', 'cudatoolkit' : '10.2'}, [])
     assert build_commands[0].packages == {'horovod'}
     assert build_commands[0].recipe_path == "my_recipe_path"
     for dep in {'build_req1', 'build_req2            1.2'}:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Re-arranges code for performing Open-CE tests. Most testing code is removed from BuildTree and build_env now calls `test_feedstock` directly.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
