### PR TITLE
Add the packages argument

### DIFF
--- a/doc/README.open_ce_build.md
+++ b/doc/README.open_ce_build.md
@@ -75,7 +75,7 @@ will require that the MPI environment is correctly set up.
 ==============================================================================
 usage: open-ce build env [-h] [--conda_build_config CONDA_BUILD_CONFIG]
                          [--output_folder OUTPUT_FOLDER]
-                         [--channels CHANNELS_LIST]
+                         [--channels CHANNELS_LIST] [--packages PACKAGES]
                          [--repository_folder REPOSITORY_FOLDER]
                          [--python_versions PYTHON_VERSIONS]
                          [--build_types BUILD_TYPES] [--mpi_types MPI_TYPES]
@@ -96,12 +96,14 @@ optional arguments:
   -h, --help            show this help message and exit
   --conda_build_config CONDA_BUILD_CONFIG
                         Location of conda_build_config.yaml file. (default:
-                        conda_build_config.yaml)
+                        None)
   --output_folder OUTPUT_FOLDER
                         Path where built conda packages will be saved.
                         (default: condabuild)
   --channels CHANNELS_LIST
                         Conda channels to be used. (default: [])
+  --packages PACKAGES   Only build this list of comma delimited packages (plus
+                        their dependencies). (default: None)
   --repository_folder REPOSITORY_FOLDER
                         Directory that contains the repositories. If the
                         repositories don't exist locally, they will be
@@ -118,8 +120,8 @@ optional arguments:
                         Comma delimited list of mpi types, such as "openmpi"
                         or "system". (default: openmpi)
   --cuda_versions CUDA_VERSIONS
-                        CUDA version to build for ,
-                        such as "10.2" or "11.0". (default: 10.2)
+                        CUDA version to build for , such as "10.2" or "11.0".
+                        (default: 10.2)
   --skip_build_packages
                         Do not perform builds of packages. (default: False)
   --run_tests           Run Open-CE tests for each potential conda environment

--- a/doc/README.open_ce_test.md
+++ b/doc/README.open_ce_test.md
@@ -68,7 +68,7 @@ The `open-ce test env` command can be used to run tests for every package listed
 ==============================================================================
 usage: open-ce test env [-h] [--conda_build_config CONDA_BUILD_CONFIG]
                         [--output_folder OUTPUT_FOLDER]
-                        [--channels CHANNELS_LIST]
+                        [--channels CHANNELS_LIST] [--packages PACKAGES]
                         [--repository_folder REPOSITORY_FOLDER]
                         [--python_versions PYTHON_VERSIONS]
                         [--build_types BUILD_TYPES] [--mpi_types MPI_TYPES]
@@ -87,12 +87,14 @@ optional arguments:
   -h, --help            show this help message and exit
   --conda_build_config CONDA_BUILD_CONFIG
                         Location of conda_build_config.yaml file. (default:
-                        conda_build_config.yaml)
+                        None)
   --output_folder OUTPUT_FOLDER
                         Path where built conda packages will be saved.
                         (default: condabuild)
   --channels CHANNELS_LIST
                         Conda channels to be used. (default: [])
+  --packages PACKAGES   Only build this list of comma delimited packages (plus
+                        their dependencies). (default: None)
   --repository_folder REPOSITORY_FOLDER
                         Directory that contains the repositories. If the
                         repositories don't exist locally, they will be
@@ -109,14 +111,14 @@ optional arguments:
                         Comma delimited list of mpi types, such as "openmpi"
                         or "system". (default: openmpi)
   --cuda_versions CUDA_VERSIONS
-                        CUDA version to build for ,
-                        such as "10.2" or "11.0". (default: 10.2)
+                        CUDA version to build for , such as "10.2" or "11.0".
+                        (default: 10.2)
   --docker_build        Perform a build within a docker container. NOTE: When
                         the --docker_build flag is used, all arguments with
                         paths should be relative to the directory containing
-                        open-ce. Only files within the open-ce directory and
-                        local_files will be visible at build time. (default:
-                        False)
+                        root level open-ce directory. Only files within the
+                        root level open-ce directory and local_files will be
+                        visible at build time. (default: False)
   --git_location GIT_LOCATION
                         The default location to clone git repositories from.
                         (default: https://github.com/open-ce)

--- a/open-ce/build_env.py
+++ b/open-ce/build_env.py
@@ -35,6 +35,7 @@ DESCRIPTION = 'Build conda environment as part of Open-CE'
 
 ARGUMENTS = [Argument.CONDA_BUILD_CONFIG, Argument.OUTPUT_FOLDER,
              Argument.CHANNELS, Argument.ENV_FILE,
+             Argument.PACKAGES,
              Argument.REPOSITORY_FOLDER, Argument.PYTHON_VERSIONS,
              Argument.BUILD_TYPES, Argument.MPI_TYPES,
              Argument.CUDA_VERSIONS, Argument.SKIP_BUILD_PACKAGES,
@@ -107,7 +108,8 @@ def build_env(args):
                                channels=args.channels_list,
                                git_location=args.git_location,
                                git_tag_for_env=args.git_tag_for_env,
-                               conda_build_config=args.conda_build_config)
+                               conda_build_config=args.conda_build_config,
+                               packages=inputs.parse_arg_list(args.packages))
 
     # Generate conda environment files
     conda_env_files = build_tree.write_conda_env_files(output_folder=os.path.abspath(args.output_folder),

--- a/open-ce/inputs.py
+++ b/open-ce/inputs.py
@@ -201,6 +201,13 @@ path of \"recipe\"."""))
                                              " to be set in the container or cpus or gpus to be used "
                                              " such as \"--build-arg ENV1=test1 --cpuset-cpus 0,1\"."))
 
+    PACKAGES = (lambda parser: parser.add_argument(
+                               '--packages',
+                               type=str,
+                               default=None,
+                               help="Only build this list of comma delimited packages (plus their dependencies)."))
+
+
 def make_parser(arguments, *args, formatter_class=OpenCEFormatter, **kwargs):
     '''
     Make a parser from a list of OPEN-CE Arguments.

--- a/open-ce/test_env.py
+++ b/open-ce/test_env.py
@@ -23,6 +23,7 @@ COMMAND = 'env'
 DESCRIPTION = 'Test Open-CE Environment'
 ARGUMENTS = [Argument.CONDA_BUILD_CONFIG, Argument.OUTPUT_FOLDER,
              Argument.CHANNELS, Argument.ENV_FILE,
+             Argument.PACKAGES,
              Argument.REPOSITORY_FOLDER, Argument.PYTHON_VERSIONS,
              Argument.BUILD_TYPES, Argument.MPI_TYPES,
              Argument.CUDA_VERSIONS, Argument.DOCKER_BUILD,

--- a/open-ce/test_env.py
+++ b/open-ce/test_env.py
@@ -17,18 +17,10 @@
 """
 
 import build_env
-from inputs import Argument
 
 COMMAND = 'env'
 DESCRIPTION = 'Test Open-CE Environment'
-ARGUMENTS = [Argument.CONDA_BUILD_CONFIG, Argument.OUTPUT_FOLDER,
-             Argument.CHANNELS, Argument.ENV_FILE,
-             Argument.PACKAGES,
-             Argument.REPOSITORY_FOLDER, Argument.PYTHON_VERSIONS,
-             Argument.BUILD_TYPES, Argument.MPI_TYPES,
-             Argument.CUDA_VERSIONS, Argument.DOCKER_BUILD,
-             Argument.GIT_LOCATION, Argument.GIT_TAG_FOR_ENV,
-             Argument.TEST_LABELS]
+ARGUMENTS = build_env.ARGUMENTS
 
 def test_env(args):
     '''Entry Function'''

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -42,6 +42,7 @@ DEFAULT_TEST_CONFIG_FILE = "tests/open-ce-tests.yaml"
 DEFAULT_GIT_TAG = None
 OPEN_CE_VARIANT = "open-ce-variant"
 DEFAULT_TEST_WORKING_DIRECTORY = "./"
+KNOWN_VARIANT_PACKAGES = ["python", "cudatoolkit"]
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):

--- a/open-ce/validate_config.py
+++ b/open-ce/validate_config.py
@@ -57,13 +57,14 @@ def validate_env_config(conda_build_config, env_config_files, variants, reposito
                 raise OpenCEError(Error.VALIDATE_CONFIG, conda_build_config, env_file, variant, err.msg) from err
             print('Successfully validated {} for {} : {}'.format(conda_build_config, env_file, variant))
 
-def validate_build_tree(build_commands, external_deps):
+def validate_build_tree(build_commands, external_deps, package_indices=None):
     '''
     Check a build tree for dependency compatability.
     '''
-    packages = [package for recipe in build_commands for package in recipe.packages]
+    packages = [package for recipe in build_tree.traverse_build_commands(build_commands, package_indices)
+                            for package in recipe.packages]
     channels = {channel for recipe in build_commands for channel in recipe.channels}
-    deps = build_tree.get_installable_packages(build_commands, external_deps)
+    deps = build_tree.get_installable_packages(build_commands, external_deps, package_indices)
 
     pkg_args = " ".join(["\"{}\"".format(utils.generalize_version(dep)) for dep in deps
                                                                     if not utils.remove_version(dep) in packages])

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -225,7 +225,7 @@ def test_build_env(mocker, capsys):
     open_ce._main(["build", build_env.COMMAND, env_file, "--cuda_versions", cuda_version])
     validate_conda_env_files(cuda_versions=cuda_version)
 
-    #---The seventh test specifices specific packages that should be built (plus their dependencies)
+    #---The seventh test specifies specific packages that should be built (plus their dependencies)
     package_deps = {"package11": ["package15"],
                     "package12": ["package11"],
                     "package13": ["package12", "package14"],

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -166,6 +166,9 @@ def test_build_env(mocker, capsys):
     open_ce._main(["build", build_env.COMMAND, env_file])
     captured = capsys.readouterr()
     assert "Skipping build of" in captured.out
+    mocker.patch(
+        'build_env._all_outputs_exist',
+        return_value=False)
 
     #---The fifth test specifies a cuda version that isn't supported in the env file by package21.
     mocker.patch(
@@ -178,12 +181,19 @@ def test_build_env(mocker, capsys):
     )
 
     cuda_version = "9.1"
+    package_deps = {"package11": ["package15"],
+                    "package12": ["package11"],
+                    "package13": ["package12", "package14"],
+                    "package14": ["package15", "package16"],
+                    "package15": [],
+                    "package16": ["package15"],
+                    "package21": ["package13"],
+                    "package22": ["package15"]}
     buildTracker = PackageBuildTracker()
     mocker.patch( # This ensures that 'package21' is not built when the cuda version is 9.1  
         'build_feedstock.build_feedstock_from_command',
         side_effect=(lambda x, *args, **kwargs: buildTracker.validate_build_feedstock(x, package_deps,
-                     conditions=[(lambda command: command.cudatoolkit == cuda_version)
-                                 (lambda command: command.recipe != "package21-feedstock")]))
+                     conditions=[(lambda command: command.recipe != "package21-feedstock")]))
     )
 
     env_file = os.path.join(test_dir, 'test-env2.yaml')
@@ -214,6 +224,36 @@ def test_build_env(mocker, capsys):
     env_file = os.path.join(test_dir, 'test-env2.yaml')
     open_ce._main(["build", build_env.COMMAND, env_file, "--cuda_versions", cuda_version])
     validate_conda_env_files(cuda_versions=cuda_version)
+
+    #---The seventh test specifices specific packages that should be built (plus their dependencies)
+    package_deps = {"package11": ["package15"],
+                    "package12": ["package11"],
+                    "package13": ["package12", "package14"],
+                    "package14": ["package15", "package16"],
+                    "package15": [],
+                    "package16": ["package15"],
+                    "package21": ["package13"],
+                    "package22": ["package21"]}
+    mocker.patch(
+        'conda_build.api.render',
+        side_effect=(lambda path, *args, **kwargs: helpers.mock_renderer(os.getcwd(), package_deps))
+    )
+    buildTracker = PackageBuildTracker()
+    mocker.patch(
+        'build_feedstock.build_feedstock_from_command',
+        side_effect=(lambda x, *args, **kwargs: buildTracker.validate_build_feedstock(x, package_deps,
+                     conditions=[(lambda command: not command.recipe in ["package11-feedstock",
+                                                                         "package12-feedstock",
+                                                                         "package13-feedstock",
+                                                                         "package21-feedstock",
+                                                                         "package22-feedstock"])]))
+    )
+
+    env_file = os.path.join(test_dir, 'test-env2.yaml')
+    captured = capsys.readouterr()
+    open_ce._main(["build", build_env.COMMAND, env_file, "--python_versions", py_version, "--packages", "package14,package35"])
+    captured = capsys.readouterr()
+    assert "No recipes were found for package35" in captured.out
 
 def validate_conda_env_files(py_versions=utils.DEFAULT_PYTHON_VERS,
                              build_types=utils.DEFAULT_BUILD_TYPES,


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #304 .

Adds the `--packages` argument to `build env`. This allows a user to only build a subset of packages from within an Open-CE environment file.

This issue also cleans up the generated conda environment files. It only adds packages that are being built (not their direct dependencies). It also adds the version number to all of the packages that are being built.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
