### PR TITLE
Add the get licenses tool

### DIFF
--- a/open-ce/errors.py
+++ b/open-ce/errors.py
@@ -49,8 +49,9 @@ class Error(Enum):
     UNSUPPORTED_CUDA = (19, "Cannot build using docker image for cuda \"{}\" no Dockerfile currently exists")
     TOO_MANY_CUDA = (20, "Only one cuda version allowed to be built with docker at a time")
     FAILED_TESTS = (21, "There were {} test failures")
-    CONDA_ENV_FILE_REQUIRED = (22, "The '--conda_env_file' argument is required to run tests.")
+    CONDA_ENV_FILE_REQUIRED = (22, "The '--conda_env_file' argument is required.")
     PATCH_APPLICATION = (23, "Failed to apply patch {} on feedstock {}")
+    GET_LICENSES = (24, "Error generating licenses file.\nCommand:\n{}\nOUTPUT:\n{}Errpr:\n{}")
 
 class OpenCEError(Exception):
     """

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -1,0 +1,94 @@
+import os
+import json
+import datetime
+import utils
+from errors import OpenCEError, Error
+from inputs import Argument
+
+COMMAND = 'licenses'
+
+DESCRIPTION = 'Gather license information for a group of packages'
+
+ARGUMENTS = [Argument.OUTPUT_FOLDER, Argument.CONDA_ENV_FILE]
+
+class LicenseGenerator():
+    class LicenseInfo():
+        def __init__(self, name, version, url, license_type):
+            self.name = name
+            self.version = version
+            self.url = url
+            self.license_type = license_type
+
+        def __str__(self):
+            return "{}\t{}\t{}\t{}".format(self.name, self.version, self.url, self.license_type)
+
+        def __lt__(self, other):
+           return self.name < other.name
+
+        def __hash__(self):
+            return hash(self.name)
+
+    def __init__(self):
+        self._licenses = set()
+
+    def add_licenses(self, conda_env_file):
+        # Create a conda environment from the provided file
+        time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+        conda_env_path = os.path.join(os.getcwd(), "license_env_file_" + time_stamp)
+        cli = "conda env create -p {} -f {}".format(conda_env_path, conda_env_file)
+        ret_code, std_out, std_err = utils.run_command_capture(cli)
+        if not ret_code:
+            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+
+        # Get all of the licenses from the file
+        self._add_licenses_from_environment(conda_env_path)
+
+        # Delete the generated conda environment
+        cli = "conda env remove -p {}".format(conda_env_path)
+        ret_code, std_out, std_err = utils.run_command_capture(cli)
+        if not ret_code:
+            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+
+    def write_licenses_file(self, output_folder):
+        result = ""
+        for license in sorted(self._licenses):
+            result += str(license) + "\n"
+
+        if not os.path.exists(output_folder):
+            os.makedirs(output_folder)
+
+        licenses_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+
+        with open(licenses_file, 'w') as f:
+            f.write(result)
+
+        print("INFO: Licenses file generated: " + licenses_file)
+
+    def _add_licenses_from_environment(self, conda_env):
+        # For each meta-pkg within an environment, find its about.json file.
+        meta_files = [meta_file for meta_file in os.listdir(os.path.join(conda_env, "conda-meta")) if meta_file.endswith('.json')]
+        license_str = []
+        for meta_file in meta_files:
+            # Find the extracted_package_dir
+            with open(os.path.join(conda_env, "conda-meta", meta_file)) as f:
+                meta_data = json.load(f)
+
+            with open(os.path.join(meta_data["extracted_package_dir"], "info", "about.json")) as f:
+                about_data = json.load(f)
+
+            info = LicenseGenerator.LicenseInfo(meta_data["name"],
+                                                meta_data["version"],
+                                                about_data.get("dev_url", about_data.get("home", "none")), 
+                                                about_data.get("license", "none"))
+            self._licenses.add(info)
+
+
+def get_licenses(args):
+    if not args.conda_env_file:
+        raise OpenCEError(Error.CONDA_ENV_FILE_REQUIRED)
+
+    gen = LicenseGenerator()
+    gen.add_licenses(args.conda_env_file)
+    gen.write_licenses_file(args.output_folder)
+
+ENTRY_FUNCTION = get_licenses

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -1,3 +1,21 @@
+"""
+# *****************************************************************
+# (C) Copyright IBM Corp. 2021. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+"""
+
 import os
 import json
 import datetime
@@ -12,7 +30,14 @@ DESCRIPTION = 'Gather license information for a group of packages'
 ARGUMENTS = [Argument.OUTPUT_FOLDER, Argument.CONDA_ENV_FILE]
 
 class LicenseGenerator():
+    """
+    The LicenseGenerator class is used to generate license information about all of
+    the packages installed within a conda environment.
+    """
     class LicenseInfo():
+        """
+        The LicenseInfo class holds license information for a single package.
+        """
         def __init__(self, name, version, url, license_type):
             self.name = name
             self.version = version
@@ -23,7 +48,7 @@ class LicenseGenerator():
             return "{}\t{}\t{}\t{}".format(self.name, self.version, self.url, self.license_type)
 
         def __lt__(self, other):
-           return self.name < other.name
+            return self.name < other.name
 
         def __hash__(self):
             return hash(self.name)
@@ -32,13 +57,17 @@ class LicenseGenerator():
         self._licenses = set()
 
     def add_licenses(self, conda_env_file):
+        """
+        Add all of the license information for every package within a given conda
+        environment file.
+        """
         # Create a conda environment from the provided file
         time_stamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         conda_env_path = os.path.join(os.getcwd(), "license_env_file_" + time_stamp)
         cli = "conda env create -p {} -f {}".format(conda_env_path, conda_env_file)
         ret_code, std_out, std_err = utils.run_command_capture(cli)
         if not ret_code:
-            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+            raise OpenCEError(Error.GET_LICENSES, cli, std_out, std_err)
 
         # Get all of the licenses from the file
         self._add_licenses_from_environment(conda_env_path)
@@ -47,43 +76,50 @@ class LicenseGenerator():
         cli = "conda env remove -p {}".format(conda_env_path)
         ret_code, std_out, std_err = utils.run_command_capture(cli)
         if not ret_code:
-            raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)
+            raise OpenCEError(Error.GET_LICENSES, cli, std_out, std_err)
 
     def write_licenses_file(self, output_folder):
+        """
+        Write all of the license information to the provided path.
+        """
         result = ""
-        for license in sorted(self._licenses):
-            result += str(license) + "\n"
+        for lic in sorted(self._licenses):
+            result += str(lic) + "\n"
 
         if not os.path.exists(output_folder):
             os.makedirs(output_folder)
 
         licenses_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
 
-        with open(licenses_file, 'w') as f:
-            f.write(result)
+        with open(licenses_file, 'w') as file_stream:
+            file_stream.write(result)
 
         print("INFO: Licenses file generated: " + licenses_file)
 
     def _add_licenses_from_environment(self, conda_env):
         # For each meta-pkg within an environment, find its about.json file.
-        meta_files = [meta_file for meta_file in os.listdir(os.path.join(conda_env, "conda-meta")) if meta_file.endswith('.json')]
-        license_str = []
+        meta_files = [meta_file for meta_file in os.listdir(os.path.join(conda_env, "conda-meta"))
+                          if meta_file.endswith('.json')]
+
         for meta_file in meta_files:
             # Find the extracted_package_dir
-            with open(os.path.join(conda_env, "conda-meta", meta_file)) as f:
-                meta_data = json.load(f)
+            with open(os.path.join(conda_env, "conda-meta", meta_file)) as file_stream:
+                meta_data = json.load(file_stream)
 
-            with open(os.path.join(meta_data["extracted_package_dir"], "info", "about.json")) as f:
-                about_data = json.load(f)
+            with open(os.path.join(meta_data["extracted_package_dir"], "info", "about.json")) as file_stream:
+                about_data = json.load(file_stream)
 
             info = LicenseGenerator.LicenseInfo(meta_data["name"],
                                                 meta_data["version"],
-                                                about_data.get("dev_url", about_data.get("home", "none")), 
+                                                about_data.get("dev_url", about_data.get("home", "none")),
                                                 about_data.get("license", "none"))
             self._licenses.add(info)
 
 
 def get_licenses(args):
+    """
+    Entry point for `get licenses`.
+    """
     if not args.conda_env_file:
         raise OpenCEError(Error.CONDA_ENV_FILE_REQUIRED)
 

--- a/open-ce/open-ce
+++ b/open-ce/open-ce
@@ -27,6 +27,7 @@ import test_env
 import validate_config
 import validate_env
 import build_image
+import get_licenses
 
 def make_parser():
     ''' Parser for input arguments '''
@@ -98,6 +99,19 @@ def make_parser():
                                                validate_env.ARGUMENTS,
                                                help=validate_env.DESCRIPTION)
     validate_env_parser.set_defaults(func=validate_env.ENTRY_FUNCTION)
+
+    get_parser = inputs.add_subparser(subparsers, 'get', [],
+                                      help="Get information about Open-CE builds.")
+    get_sub_parsers = get_parser.add_subparsers(title='Get Commands',
+                                                description='Valid Commands')
+    get_sub_parsers.required = True
+    get_sub_parsers.dest = 'sub_command'
+
+    get_licenses_parser = inputs.add_subparser(get_sub_parsers,
+                                               get_licenses.COMMAND,
+                                               get_licenses.ARGUMENTS,
+                                               help=get_licenses.DESCRIPTION)
+    get_licenses_parser.set_defaults(func=get_licenses.ENTRY_FUNCTION)
 
     return parser
 

--- a/open-ce/open-ce
+++ b/open-ce/open-ce
@@ -29,6 +29,7 @@ import validate_env
 import build_image
 import get_licenses
 
+#pylint: disable=too-many-locals
 def make_parser():
     ''' Parser for input arguments '''
     parser = inputs.make_parser([], description = 'Open-CE Tool')

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -43,6 +43,7 @@ DEFAULT_GIT_TAG = None
 OPEN_CE_VARIANT = "open-ce-variant"
 DEFAULT_TEST_WORKING_DIRECTORY = "./"
 KNOWN_VARIANT_PACKAGES = ["python", "cudatoolkit"]
+DEFAULT_LICENSES_FILE = "licenses.csv"
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -1,0 +1,80 @@
+# *****************************************************************
+# (C) Copyright IBM Corp. 2021. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+
+import sys
+import os
+import pathlib
+import pytest
+import imp
+import shutil
+
+test_dir = pathlib.Path(__file__).parent.absolute()
+sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
+open_ce = imp.load_source('open_ce', os.path.join(test_dir, '..', 'open-ce', 'open-ce'))
+import get_licenses
+import utils
+from errors import OpenCEError
+
+def test_get_licenses():
+    '''
+    This is a complete test of `get_licenses`.
+    '''
+    output_folder = "get_licenses_output"
+    open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+
+    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    assert os.path.exists(output_file)
+    with open(output_file) as file_stream:
+        license_contents = file_stream.read()
+
+    print(license_contents)
+    assert "pytest	6.2.2	https://github.com/pytest-dev/pytest/	MIT" in license_contents
+
+    shutil.rmtree(output_folder)
+
+def test_get_licenses_failed_conda_create(mocker):
+    '''
+    This tests that an exception is thrown when `conda env create` fails.
+    '''
+    output_folder = "get_licenses_output"
+    mocker.patch('utils.run_command_capture', side_effect=[(False, "", "")])
+
+    with pytest.raises(OpenCEError) as err:
+        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+
+    assert "Error generating licenses file." in str(err.value)
+
+def test_get_licenses_failed_conda_remove(mocker):
+    '''
+    This tests that an exception is thrown when `conda env remove` is called.
+    '''
+    output_folder = "get_licenses_output"
+    mocker.patch('utils.run_command_capture', side_effect=[(True, "", ""), (False, "", "")])
+    mocker.patch('get_licenses.LicenseGenerator._add_licenses_from_environment', return_value=[])
+
+    with pytest.raises(OpenCEError) as err:
+        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+
+    assert "Error generating licenses file." in str(err.value)
+
+def test_get_licenses_no_conda_env():
+    '''
+    This test ensures that an exception is thrown when no conda environment is provided.
+    '''
+    with pytest.raises(OpenCEError) as err:
+        open_ce._main(["get", get_licenses.COMMAND])
+
+    assert "The \'--conda_env_file\' argument is required." in str(err.value)

--- a/tests/test-conda-env2.yaml
+++ b/tests/test-conda-env2.yaml
@@ -2,5 +2,5 @@
 channels:
 - defaults
 dependencies:
-- pytest
+- pytest 6.2.2
 name: opence-conda-env-py3.6-cuda-openmpi


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Creates a tool called `open-ce get licenses` that compiles a list of all of the license information for a collection of packages within a conda environment file.

Future work includes:
1. Add documentation
1. Determine packages pulled in outside of conda at build time.
1. Grab copyright information.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
