### PR TITLE
adjust pins for 1.1.x

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -50,7 +50,7 @@ dm_tree:
 eigen:
   - 3.3.7
 ffmpeg:
-  - 4.2.0
+  - 4.2.*
 flatbuffers:
   - 1.12.*
 freetype:

--- a/envs/dali-env.yaml
+++ b/envs/dali-env.yaml
@@ -10,7 +10,7 @@ packages:
   - feedstock : jpeg-turbo
   - feedstock : libflac
   - feedstock : libsndfile
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
 {% endif %}
 
 git_tag_for_env: open-ce-v1.1.2

--- a/envs/pytorch-env.yaml
+++ b/envs/pytorch-env.yaml
@@ -16,6 +16,6 @@ packages:
   - feedstock : onnx
   - feedstock : av
   - feedstock : torchvision
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
 
 git_tag_for_env: open-ce-v1.1.2

--- a/envs/tensorboard-env.yaml
+++ b/envs/tensorboard-env.yaml
@@ -4,6 +4,6 @@ imported_envs:
 packages:
   - feedstock : tensorboard
   - feedstock : tensorboard-plugin-wit
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
 
 git_tag_for_env: open-ce-v1.1.2

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -21,7 +21,7 @@ packages:
   - feedstock : tensorflow-hub
   - feedstock : tensorflow-metadata
   - feedstock : tensorflow-datasets
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
   - feedstock : tensorflow-text
   - feedstock : tensorflow-model-optimization
   - feedstock : tensorflow-addons

--- a/envs/tensorrt-env.yaml
+++ b/envs/tensorrt-env.yaml
@@ -1,12 +1,12 @@
 packages:
 {% set py_ver = python | float %}
 {% if build_type == 'cuda' %}
-  - feedstock: libc_wrappers     #[cudatoolkit == '11.0']
+  - feedstock: libc_wrappers     #[x86_64 and cudatoolkit == '11.0']
 {% if py_ver < 3.8 %}
   - feedstock : cudnn
   - feedstock : tensorrt
   - feedstock : onnx
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
 {% endif %}
 {% endif %}
 

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -2,7 +2,7 @@ packages:
   - feedstock : rust-nightly
   - feedstock : semantic
   - feedstock : tokenizers
-  - feedstock : protobuf          #[python == '3.8']
+  - feedstock : protobuf          #[ppc64le and python == '3.8']
   - feedstock : sentencepiece
   - feedstock : sacremoses
   - feedstock : transformers


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This PR does a few things:
 - reverts https://github.com/open-ce/open-ce/pull/269
 - protobuf 3.9 py38 is available from defaults on x86_64; only build it for ppc64le
 - only build the libc_wrappers for x86_64

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
