### PR TITLE
Fixed docker_build when no = is used between the arguments and values

### DIFF
--- a/open-ce/docker_build.py
+++ b/open-ce/docker_build.py
@@ -41,7 +41,7 @@ DOCKER_TOOL = "docker"
 def make_parser():
     ''' Parser for input arguments '''
     arguments = [Argument.DOCKER_BUILD, Argument.OUTPUT_FOLDER,
-                 Argument.CONDA_BUILD_CONFIG, Argument.ENV_FILE, Argument.DOCKER_BUILD_ARGS]
+                 Argument.CONDA_BUILD_CONFIG, Argument.DOCKER_BUILD_ARGS]
     parser = argparse.ArgumentParser(arguments)
     parser.add_argument('command_placeholder', nargs=1, type=str)
     parser.add_argument('sub_command_placeholder', nargs=1, type=str)
@@ -214,6 +214,14 @@ def build_with_docker(args, arg_strings):
     """
     Create a build image and run a build inside of container based on that image.
     """
+
+    # env_config_file being positional argument cause problem while parsing known
+    # arguments. Hence removing it from arg_strings, as it is anyway being read
+    # from args ahead.
+    for env_file in args.env_config_file:
+        if env_file in arg_strings:
+            arg_strings.remove(env_file)
+
     parser = make_parser()
     _, unused_args = parser.parse_known_args(arg_strings[1:])
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes #318 

Python's argparse.parse_known_args can't parse the mixed arguments containing positional and optional arguments correctly specially when type of positional argument and type of other arguments are same.

For e.g. If ['build', 'env', '--python_versions', '3.7', '--build_types', 'cuda', 'envs/tensorflow-env.yaml'] is passed to parse_known_args method ( with cmd, sub-cmd, env_file as known arguments), it will assign '3.7' to env_file leaving ['--python_versions', '--build_type', 'cuda', 'envs/tensorflow-env.yaml'] as unknown arguments. And hence the error mentioned in #318 comes up. I checked other methods of argparse too like parse_intermixed_known_args but it also doesn't give the right results in this case.

So, as a solution, I think it is better to remove env_file arguments while filtering known/unknown arguments. env_file argument is anyway read later on from the `args` namespace object. Going forward, if we add another positional arguments like env_file, those will also need to be removed before sending them to parse_known_args.

Workaround is either to supply env_file just after build env or add `=` in the argument names and their values.

 
## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
