### PR TITLE
Bump 11.0 build image to stay current with upstream.

### DIFF
--- a/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
+++ b/images/builder-cuda-ppc64le/Dockerfile.cuda-11.0
@@ -1,4 +1,4 @@
-FROM nvidia/cuda-ppc64le:11.0-devel-ubi8
+FROM nvidia/cuda-ppc64le:11.0.3-devel-ubi8
 
 ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
 ENV PATH=$CONDA_HOME/bin:$PATH

--- a/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
+++ b/images/builder-cuda-x86_64/Dockerfile.cuda-11.0
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.0-devel-ubi8
+FROM nvidia/cuda:11.0.3-devel-ubi8
 
 ENV CONDA_HOME=${CONDA_HOME:-/opt/conda}
 ENV PATH=$CONDA_HOME/bin:$PATH


### PR DESCRIPTION
dockerhub's nvidia/cuda-ppc64le hasn't updated the 11.0-devel-ubi8 image in
4 months now.  They appear to have moved to 11.0.3, as the latest
and only 11.0 build being kept up to date.  Move our 11.0 build
Dockerfile to pull from there instead.

## Checklist before submitting

- [X] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
