### PR TITLE
Get copyright info

### DIFF
--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -446,22 +446,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             else:
                 git_tag = env_config_data.get(env_config.Key.git_tag_for_env.name, None) if env_config_data else None
 
-        clone_cmd = "git clone " + git_url + " " + repo_dir
-        print("Clone cmd: ", clone_cmd)
-        clone_result = os.system(clone_cmd)
-
-        cur_dir = os.getcwd()
-        clone_successful = clone_result == 0
-        if clone_successful:
-            if not git_tag is None:
-                os.chdir(repo_dir)
-                checkout_cmd = "git checkout " + git_tag
-                print("Checkout branch/tag command: ", checkout_cmd)
-                checkout_res = os.system(checkout_cmd)
-                os.chdir(cur_dir)
-                clone_successful = checkout_res == 0
-        else:
-            raise OpenCEError(Error.CLONE_REPO, git_url)
+        clone_successful = utils.git_clone(git_url, git_tag, repo_dir)
 
         if clone_successful:
             patches = package.get(env_config.Key.patches.name, []) if package else []

--- a/open-ce/build_tree.py
+++ b/open-ce/build_tree.py
@@ -451,6 +451,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         if clone_successful:
             patches = package.get(env_config.Key.patches.name, []) if package else []
             if len(patches) > 0:
+                cur_dir = os.getcwd()
                 os.chdir(repo_dir)
                 for patch in patches:
                     if os.path.isabs(patch) and os.path.exists(patch):

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -90,7 +90,7 @@ class LicenseGenerator():
         def __str__(self):
             return "{}\t{}\t{}\t{}\t{}".format(self.name,
                                                self.version,
-                                               self.url,
+                                               ", ".join(self.url) if isinstance(self.url, list) else self.url,
                                                self.license_type,
                                                ", ".join(self.copyrights))
 

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -61,7 +61,7 @@ _THIRD_PARTY_PACKAGE_SCHEMA ={
     Key.name.name: utils.make_schema_type(str, True),
     Key.version.name: utils.make_schema_type(str, True),
     Key.license.name: utils.make_schema_type(str, True),
-    Key.url.name: utils.make_schema_type(str, True),
+    Key.url.name: utils.make_schema_type([str], True),
     Key.license_url.name: utils.make_schema_type(str),
     Key.copyright_string.name: utils.make_schema_type(str),
 }
@@ -308,6 +308,7 @@ def _find_license_files(directory):
     license_files += glob.glob(os.path.join(directory, "**", "*LICENSE*"), recursive=True)
     license_files += glob.glob(os.path.join(directory, "**", "*LICENCE*"), recursive=True)
     license_files += glob.glob(os.path.join(directory, "**", "*COPYING*"), recursive=True)
+    license_files += glob.glob(os.path.join(directory, "**", "*CopyrightNotice*"), recursive=True)
     license_files += glob.glob(os.path.join(directory, "**", "*d.ts"), recursive=True)
 
     return license_files

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -47,6 +47,7 @@ DEFAULT_TEST_WORKING_DIRECTORY = "./"
 KNOWN_VARIANT_PACKAGES = ["python", "cudatoolkit"]
 DEFAULT_LICENSES_FILE = "licenses.csv"
 TMP_LICENSE_DIR = "tmp_license_src"
+OPEN_CE_INFO_FILE = "open-ce-info.yaml"
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -270,6 +270,9 @@ def replace_conda_env_channels(conda_env_file, original_channel, new_channel):
         yaml.safe_dump(env_info, file_handle)
 
 def git_clone(git_url, git_tag, location):
+    '''
+    Clone a git repository and checkout a certain branch.
+    '''
     clone_cmd = "git clone " + git_url + " " + location
     print("Clone cmd: ", clone_cmd)
     clone_result = os.system(clone_cmd)

--- a/open-ce/utils.py
+++ b/open-ce/utils.py
@@ -46,6 +46,7 @@ OPEN_CE_VARIANT = "open-ce-variant"
 DEFAULT_TEST_WORKING_DIRECTORY = "./"
 KNOWN_VARIANT_PACKAGES = ["python", "cudatoolkit"]
 DEFAULT_LICENSES_FILE = "licenses.csv"
+TMP_LICENSE_DIR = "tmp_license_src"
 
 def make_variants(python_versions=DEFAULT_PYTHON_VERS, build_types=DEFAULT_BUILD_TYPES, mpi_types=DEFAULT_MPI_TYPES,
 cuda_versions=DEFAULT_CUDA_VERS):
@@ -267,3 +268,23 @@ def replace_conda_env_channels(conda_env_file, original_channel, new_channel):
 
     with open(conda_env_file, 'w') as file_handle:
         yaml.safe_dump(env_info, file_handle)
+
+def git_clone(git_url, git_tag, location):
+    clone_cmd = "git clone " + git_url + " " + location
+    print("Clone cmd: ", clone_cmd)
+    clone_result = os.system(clone_cmd)
+
+    cur_dir = os.getcwd()
+    clone_successful = clone_result == 0
+    if clone_successful:
+        if not git_tag is None:
+            os.chdir(location)
+            checkout_cmd = "git checkout " + git_tag
+            print("Checkout branch/tag command: ", checkout_cmd)
+            checkout_res = os.system(checkout_cmd)
+            os.chdir(cur_dir)
+            clone_successful = checkout_res == 0
+    else:
+        raise OpenCEError(Error.CLONE_REPO, git_url)
+
+    return clone_successful

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -28,12 +28,16 @@ import get_licenses
 import utils
 from errors import OpenCEError
 
-def test_get_licenses():
+def test_get_licenses(capsys):
     '''
     This is a complete test of `get_licenses`.
     '''
     output_folder = "get_licenses_output"
-    open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+    open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder])
+
+    captured = capsys.readouterr()
+    assert "Unable to clone source for libopus-1.3.1" in captured.out
+    assert "Unable to download source for icu-58.2" in captured.out
 
     output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
@@ -53,7 +57,7 @@ def test_get_licenses_failed_conda_create(mocker):
     mocker.patch('utils.run_command_capture', side_effect=[(False, "", "")])
 
     with pytest.raises(OpenCEError) as err:
-        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder])
 
     assert "Error generating licenses file." in str(err.value)
 
@@ -66,7 +70,7 @@ def test_get_licenses_failed_conda_remove(mocker):
     mocker.patch('get_licenses.LicenseGenerator._add_licenses_from_environment', return_value=[])
 
     with pytest.raises(OpenCEError) as err:
-        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--output_folder", output_folder])
+        open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder])
 
     assert "Error generating licenses file." in str(err.value)
 
@@ -78,3 +82,69 @@ def test_get_licenses_no_conda_env():
         open_ce._main(["get", get_licenses.COMMAND])
 
     assert "The \'--conda_env_file\' argument is required." in str(err.value)
+
+def test_add_licenses_from_info_file(capsys):
+    '''
+    This is a complete test of the add_licenses_from_info_file method.
+    '''
+    output_folder = "get_licenses_output"
+    gen = get_licenses.LicenseGenerator()
+    gen.add_licenses_from_info_file(os.path.join("tests", "test-open-ce-info-1.yaml"))
+
+    captured = capsys.readouterr()
+    assert "Unable to clone source for bad_git_package" in captured.out
+    assert "Unable to download source for bad_url" in captured.out
+
+    gen.write_licenses_file(output_folder)
+
+    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    assert os.path.exists(output_file)
+    with open(output_file) as file_stream:
+        license_contents = file_stream.read()
+
+    print(license_contents)
+    assert "DefinitelyTyped.google.analytics\tebc69904eb78f94030d5d517b42db20867f679c0\thttps://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts\tMIT\tCopyright Jed Mao <https://github.com/jedmao/>,, Copyright Bart van der Schoor <https://github.com/Bartvds>,, Copyright Andrew Brown <https://github.com/AGBrown>,, Copyright Olivier Chevet <https://github.com/olivr70>" in license_contents
+    assert "bad_url\t1.2.3\tnot_a_url.tar.gz\tNO_LICENSE\tNot a real copy right" in license_contents
+    assert "google-test\t1.7.0\thttps://github.com/google/googletest/archive/release-1.7.0.zip\tBSD-equivalent\tCopyright 2008, Google Inc. All rights reserved." in license_contents
+    assert "kissfft\t36dbc057604f00aacfc0288ddad57e3b21cfc1b8\thttps://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz\tBSD-equivalent\tCopyright (c) 2003-2010 Mark Borgerding . All rights reserved." in license_contents
+
+    # Make sure google-test only appears once
+    assert license_contents.count("google-test\t1.7.0") == 1
+    shutil.rmtree(output_folder)
+    shutil.rmtree(utils.TMP_LICENSE_DIR)
+
+def test_bad_info_file():
+    '''
+    Test that an empty file is returned when an info file has no third_party_packages.
+    '''
+    output_folder = "get_licenses_output"
+    gen = get_licenses.LicenseGenerator()
+    gen.add_licenses_from_info_file(os.path.join("tests", "test-conda-env.yaml"))
+    gen.write_licenses_file(output_folder)
+
+    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    assert os.path.exists(output_file)
+    with open(output_file) as file_stream:
+        license_contents = file_stream.read()
+
+    assert license_contents == ""
+
+    shutil.rmtree(output_folder)
+
+def test_no_info_file():
+    '''
+    Test that an empty file is returned when an info file doesn't exist at the provided path.
+    '''
+    output_folder = "get_licenses_output"
+    gen = get_licenses.LicenseGenerator()
+    gen.add_licenses_from_info_file(os.path.join("tests", "no-file.yaml"))
+    gen.write_licenses_file(output_folder)
+
+    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
+    assert os.path.exists(output_file)
+    with open(output_file) as file_stream:
+        license_contents = file_stream.read()
+
+    assert license_contents == ""
+
+    shutil.rmtree(output_folder)

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -113,24 +113,6 @@ def test_add_licenses_from_info_file(capsys):
     shutil.rmtree(output_folder)
     shutil.rmtree(utils.TMP_LICENSE_DIR)
 
-def test_bad_info_file():
-    '''
-    Test that an empty file is returned when an info file has no third_party_packages.
-    '''
-    output_folder = "get_licenses_output"
-    gen = get_licenses.LicenseGenerator()
-    gen.add_licenses_from_info_file(os.path.join("tests", "test-conda-env.yaml"))
-    gen.write_licenses_file(output_folder)
-
-    output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
-    assert os.path.exists(output_file)
-    with open(output_file) as file_stream:
-        license_contents = file_stream.read()
-
-    assert license_contents == ""
-
-    shutil.rmtree(output_folder)
-
 def test_no_info_file():
     '''
     Test that an empty file is returned when an info file doesn't exist at the provided path.

--- a/tests/test-conda-env3.yaml
+++ b/tests/test-conda-env3.yaml
@@ -1,0 +1,8 @@
+#open-ce-variant:py3.6-cuda-openmpi-10.2
+channels:
+- defaults
+dependencies:
+- pytest 6.2.2
+- libopus 1.3.1
+- icu 58.2
+name: opence-conda-env-py3.6-cuda-openmpi

--- a/tests/test-open-ce-info-1.yaml
+++ b/tests/test-open-ce-info-1.yaml
@@ -1,0 +1,32 @@
+third_party_packages:
+# Test downloading a TypeScript file
+- name: DefinitelyTyped.google.analytics
+  license: MIT
+  url: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts
+  version: ebc69904eb78f94030d5d517b42db20867f679c0
+# Test downloading a zip file
+- name: google-test
+  license: BSD-equivalent
+  url: https://github.com/google/googletest/archive/release-1.7.0.zip
+  version: 1.7.0
+# Test duplicate entries
+- name: google-test
+  license: BSD-equivalent
+  url: https://github.com/google/googletest/archive/release-1.7.0.zip
+  version: 1.7.0
+# Test searching a repo that has a directory named LICENSE
+- name: kissfft
+  license: BSD-equivalent
+  url: https://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz
+  version: 36dbc057604f00aacfc0288ddad57e3b21cfc1b8
+# Test downloading a git repository that doesn't exist
+- name: bad_git_package
+  license: NO_LICENSE
+  url: not_a_url.git
+  version: 6.0.0
+# Test downloading a tar file that doesn't exist
+- name: bad_url
+  license: NO_LICENSE
+  url: not_a_url.tar.gz
+  version: 1.2.3
+  copyright_string: "Not a real copy right"

--- a/tests/test-open-ce-info-1.yaml
+++ b/tests/test-open-ce-info-1.yaml
@@ -2,31 +2,37 @@ third_party_packages:
 # Test downloading a TypeScript file
 - name: DefinitelyTyped.google.analytics
   license: MIT
-  url: https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts
+  url:
+    - https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/ebc69904eb78f94030d5d517b42db20867f679c0/chai/chai.d.ts
   version: ebc69904eb78f94030d5d517b42db20867f679c0
 # Test downloading a zip file
 - name: google-test
   license: BSD-equivalent
-  url: https://github.com/google/googletest/archive/release-1.7.0.zip
+  url:
+    - https://github.com/google/googletest/archive/release-1.7.0.zip
   version: 1.7.0
 # Test duplicate entries
 - name: google-test
   license: BSD-equivalent
-  url: https://github.com/google/googletest/archive/release-1.7.0.zip
+  url:
+    - https://github.com/google/googletest/archive/release-1.7.0.zip
   version: 1.7.0
 # Test searching a repo that has a directory named LICENSE
 - name: kissfft
   license: BSD-equivalent
-  url: https://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz
+  url:
+    - https://github.com/mborgerding/kissfft/archive/36dbc057604f00aacfc0288ddad57e3b21cfc1b8.tar.gz
   version: 36dbc057604f00aacfc0288ddad57e3b21cfc1b8
 # Test downloading a git repository that doesn't exist
 - name: bad_git_package
   license: NO_LICENSE
-  url: not_a_url.git
+  url:
+    - not_a_url.git
   version: 6.0.0
 # Test downloading a tar file that doesn't exist
 - name: bad_url
   license: NO_LICENSE
-  url: not_a_url.tar.gz
+  url:
+    - not_a_url.tar.gz
   version: 1.2.3
   copyright_string: "Not a real copy right"

--- a/tests/test_feedstock_test.py
+++ b/tests/test_feedstock_test.py
@@ -19,6 +19,7 @@ import os
 import pathlib
 import pytest
 import imp
+import shutil
 
 test_dir = pathlib.Path(__file__).parent.absolute()
 sys.path.append(os.path.join(test_dir, '..', 'open-ce'))
@@ -75,7 +76,7 @@ def test_test_feedstock_working_dir(mocker, capsys):
     assert not os.path.exists(working_dir)
     open_ce._main(["test", test_feedstock.COMMAND, "--conda_env_file", "tests/test-conda-env2.yaml", "--test_working_dir", working_dir])
     assert os.path.exists(working_dir)
-    os.rmdir(working_dir)
+    shutil.rmtree(working_dir)
     captured = capsys.readouterr()
     assert "Running: Create conda environment " + utils.CONDA_ENV_FILENAME_PREFIX in captured.out
     assert "Running: Test 1" in captured.out


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

This PR adds the ability to obtain copyright information for all packages within a conda environment by adding the following functionality:

- Checks for copyrights within the license file provided by a conda package.
- If no license file is provided, downloads the source used to create the conda package and finds all possible license files. Then looks for copyrights within those license files.
- Looks to see if an "Open CE Info" file exists for a package.
    - This file can contain information on third party packages that were used at build time.
    - Source from the third party packages is then downloaded.
    - Looks for copyrights within all potential license files.

Documentation will be added in a future issue.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
