### PR TITLE
Add rename_branch to rename a branch name programmatically

### DIFF
--- a/git_tools/git_utils.py
+++ b/git_tools/git_utils.py
@@ -117,6 +117,20 @@ def create_release(github_org, repo, token, tag_name, name, body, draft):# pylin
         raise Exception("Error creating github release.")
     return yaml.safe_load(result.content)
 
+def rename_branch(github_org, repo, token, old_name, new_name):# pylint: disable=too-many-arguments
+    '''
+    Use the github API to rename a branch
+    https://docs.github.com/en/rest/reference/repos#rename-a-branch
+    '''
+    result = requests.post("{}/repos/{}/{}/branches/{}/rename".format(GITHUB_API, github_org, repo, old_name),
+                            headers={'Authorization' : 'token {}'.format(token)},
+                            json={
+                            "new_name": new_name
+                            })
+    if result.status_code != 201:
+        raise Exception("Error renaming github release.")
+    return yaml.safe_load(result.content)
+
 def create_pr(github_org, repo, token, title, body, head, base):# pylint: disable=too-many-arguments
     '''
     Create a PR in the given Repo.


### PR DESCRIPTION
## Checklist before submitting

- [x ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

I was experimenting with this and used it to do the `master` to `main` rename programmatically,
in the service of #290 .... and it seems to have worked to rename them all.

So, maybe we should keep this???
(May not ever need it again, but who knows; and it is a snapshot of what was used for this occasion).


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
