### PR TITLE
Enable cuda in runtime image

### DIFF
--- a/doc/README.open_ce_build.md
+++ b/doc/README.open_ce_build.md
@@ -323,3 +323,10 @@ optional arguments:
 
 ==============================================================================
 ```
+
+### Further details of the OpenCE runtime image
+
+The Dockerfile for this runtime image is located in [`images/opence-runtime/Dockerfile`](https://github.com/open-ce/open-ce/blob/main/images/opence-runtime/Dockerfile).
+This file can also be built and run manually and supports GPUs if the system is set up with
+`nvidia-container-runtime`. When building the Dockerfile directly, it does require a few arguents,
+check the Dockerfile for details.

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -84,27 +84,27 @@ def build_runtime_container_image(args):
         conda_env_file = os.path.abspath(conda_env_file)
         _validate_input_paths(local_conda_channel, conda_env_file)
 
-    # Copy the conda environment file into the local conda channel with a new name and modify it
-    conda_env_runtime_filename = os.path.splitext(os.path.basename(args.conda_env_file))[0]+'-runtime.yaml'
-    conda_env_runtime_file = os.path.join(local_conda_channel, os.path.basename(conda_env_runtime_filename))
-    try:
-        shutil.copy(conda_env_file, conda_env_runtime_file)
-    except shutil.SameFileError:
-        print("Info: Environment file already in local conda channel.")
-    utils.replace_conda_env_channels(conda_env_runtime_file, r'file:.*', "file:/{}".format(TARGET_DIR))
+        # Copy the conda environment file into the local conda channel with a new name and modify it
+        conda_env_runtime_filename = os.path.splitext(os.path.basename(args.conda_env_file))[0]+'-runtime.yaml'
+        conda_env_runtime_file = os.path.join(local_conda_channel, os.path.basename(conda_env_runtime_filename))
+        try:
+            shutil.copy(conda_env_file, conda_env_runtime_file)
+        except shutil.SameFileError:
+            print("Info: Environment file already in local conda channel.")
+        utils.replace_conda_env_channels(conda_env_runtime_file, r'file:.*', "file:/{}".format(TARGET_DIR))
 
         # Check if input local conda channel path is absolute
         if os.path.isabs(args.local_conda_channel):
             # make it relative to BUILD CONTEXT
             args.local_conda_channel = os.path.relpath(args.local_conda_channel, start=BUILD_CONTEXT)
 
-    image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file))
+        image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file))
 
-    # Remove the copied environment file
-    try:
-        os.remove(conda_env_runtime_file)
-    except OSError:
-        print("Info: Temporary environment file cannot be removed.")
+        # Remove the copied environment file
+        try:
+            os.remove(conda_env_runtime_file)
+        except OSError:
+            print("Info: Temporary environment file cannot be removed.")
 
         print("Docker image with name {} is built successfully.".format(image_name))
 

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -100,7 +100,7 @@ def build_runtime_docker_image(args):
     try:
         os.remove(conda_env_runtime_file)
     except OSError:
-        print("Info: Temporary environment cannot be removed.")
+        print("Info: Temporary environment file cannot be removed.")
 
     print("Docker image with name {} is built successfully.".format(image_name))
 

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -98,7 +98,8 @@ def build_runtime_container_image(args):
             # make it relative to BUILD CONTEXT
             args.local_conda_channel = os.path.relpath(args.local_conda_channel, start=BUILD_CONTEXT)
 
-        image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file))
+        image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_file),
+                                 args.container_tool, args.container_build_args)
 
         # Remove the copied environment file
         try:

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -80,20 +80,22 @@ def build_runtime_docker_image(args):
     conda_env_file = os.path.abspath(args.conda_env_file)
     _validate_input_paths(local_conda_channel, conda_env_file)
 
-    # Copy the conda environment file into the local conda channel to modify it
+    # Copy the conda environment file into the local conda channel with a new name and modify it
+    conda_env_runtime_filename = os.path.splitext(os.path.basename(args.conda_env_file))[0]+'-runtime.yaml'
+    conda_env_runtime_file = os.path.join(local_conda_channel, os.path.basename(conda_env_runtime_filename))
+
     try:
-        shutil.copy(conda_env_file, local_conda_channel)
+        shutil.copy(conda_env_file, conda_env_runtime_file)
     except shutil.SameFileError:
         print("Info: Environment file already in local conda channel.")
-    conda_env_file = os.path.join(local_conda_channel, os.path.basename(conda_env_file))
-    utils.replace_conda_env_channels(conda_env_file, r'file:.*', "file:/{}".format(TARGET_DIR))
+    utils.replace_conda_env_channels(conda_env_runtime_file, r'file:.*', "file:/{}".format(TARGET_DIR))
 
     # Check if input local conda channel path is absolute
     if os.path.isabs(args.local_conda_channel):
         # make it relative to BUILD CONTEXT
         args.local_conda_channel = os.path.relpath(args.local_conda_channel, start=BUILD_CONTEXT)
 
-    image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_file))
+    image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file))
 
     print("Docker image with name {} is built successfully.".format(image_name))
 

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -81,7 +81,10 @@ def build_runtime_docker_image(args):
     _validate_input_paths(local_conda_channel, conda_env_file)
 
     # Copy the conda environment file into the local conda channel to modify it
-    shutil.copy(conda_env_file, local_conda_channel)
+    try:
+        shutil.copy(conda_env_file, local_conda_channel)
+    except shutil.SameFileError:
+        print("Info: Environment file already in local conda channel.")
     conda_env_file = os.path.join(local_conda_channel, os.path.basename(conda_env_file))
     utils.replace_conda_env_channels(conda_env_file, r'file:.*', "file:/{}".format(TARGET_DIR))
 

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -85,7 +85,7 @@ def build_runtime_container_image(args):
         _validate_input_paths(local_conda_channel, conda_env_file)
 
         # Copy the conda environment file into the local conda channel with a new name and modify it
-        conda_env_runtime_filename = os.path.splitext(os.path.basename(args.conda_env_file))[0]+'-runtime.yaml'
+        conda_env_runtime_filename = os.path.splitext(os.path.basename(conda_env_file))[0]+'-runtime.yaml'
         conda_env_runtime_file = os.path.join(local_conda_channel, os.path.basename(conda_env_runtime_filename))
         try:
             shutil.copy(conda_env_file, conda_env_runtime_file)

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -83,7 +83,6 @@ def build_runtime_docker_image(args):
     # Copy the conda environment file into the local conda channel with a new name and modify it
     conda_env_runtime_filename = os.path.splitext(os.path.basename(args.conda_env_file))[0]+'-runtime.yaml'
     conda_env_runtime_file = os.path.join(local_conda_channel, os.path.basename(conda_env_runtime_filename))
-
     try:
         shutil.copy(conda_env_file, conda_env_runtime_file)
     except shutil.SameFileError:
@@ -96,6 +95,12 @@ def build_runtime_docker_image(args):
         args.local_conda_channel = os.path.relpath(args.local_conda_channel, start=BUILD_CONTEXT)
 
     image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file))
+
+    # Remove the copied environment file
+    try:
+        os.remove(conda_env_runtime_file)
+    except OSError:
+        print("Info: Temporary environment cannot be removed.")
 
     print("Docker image with name {} is built successfully.".format(image_name))
 

--- a/open_ce/images/opence-runtime/Dockerfile
+++ b/open_ce/images/opence-runtime/Dockerfile
@@ -10,9 +10,15 @@ ARG LOCAL_CONDA_CHANNEL
 ARG CONDA_ENV_FILE
 ARG TARGET_DIR
 
-ENV OPENCE_GROUP=OPENCE_USER
+ENV OPENCE_GROUP=${OPENCE_USER}
 ARG GROUP_ID=1500
 ARG USER_ID=1084
+
+# GPUs
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES all
+ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+ENV NVIDIA_REQUIRE_CUDA "cuda>=10.2"
 
 # Install basic requirements.
 RUN export ARCH="$(uname -m)" && \
@@ -48,6 +54,6 @@ RUN mkdir -p ${TARGET_DIR}
 
 COPY ${LOCAL_CONDA_CHANNEL} ${TARGET_DIR}
 
-RUN sudo chown -R ${OPENCE_USER}:${OPENCE_GROUP} ${TARGET_DIR} && \
-    $CONDA_HOME/bin/conda env create -f ${TARGET_DIR}/${CONDA_ENV_FILE}
+RUN sudo chown -R ${OPENCE_USER}:${OPENCE_GROUP} ${TARGET_DIR}
 
+RUN if [ -n "$CONDA_ENV_FILE" ]; then $CONDA_HOME/bin/conda env create -f ${TARGET_DIR}/${CONDA_ENV_FILE}; fi

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -43,7 +43,7 @@ def test_build_image_positive_case(mocker):
                                                                "-t " + intended_image_name])))
 
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", "tests/testcondabuild", "--conda_env_file", "tests/test-conda-env.yaml"]
-    open_ce._main(arg_strings)
+    opence._main(arg_strings)
 
 def test_not_existing_local_conda_channel():
     '''
@@ -97,7 +97,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
                                                                "-t " + intended_image_name])))
 
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env.yaml"]
-    open_ce._main(arg_strings)
+    opence._main(arg_strings)
 
 def test_for_failed_docker_build_cmd(mocker):
     '''
@@ -107,7 +107,7 @@ def test_for_failed_docker_build_cmd(mocker):
 
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", "tests/testcondabuild", "--conda_env_file", "tests/test-conda-env.yaml"]
     with pytest.raises(OpenCEError) as exc:
-        open_ce._main(arg_strings)
+        opence._main(arg_strings)
     assert "Failure building image" in str(exc.value)
 
 def test_modified_file_removed(mocker):
@@ -123,6 +123,6 @@ def test_modified_file_removed(mocker):
         side_effect=(lambda x: helpers.validate_cli(x, expect=["docker build",
                                                                "-t " + intended_image_name])))
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", "tests/testcondabuild", "--conda_env_file", "tests/test-conda-env.yaml"]
-    open_ce._main(arg_strings)
+    opence._main(arg_strings)
 
     assert not os.path.exists("tests/testcondabuild/test-conda-env-runtime.yaml")

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -146,3 +146,4 @@ def test_build_image_with_container_build_args(mocker):
     build_args = "--build-arg ENV1=test1 --build-arg ENV2=test2 same_setting 0,1"
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", "tests/testcondabuild", "--conda_env_file", "tests/test-conda-env.yaml", "--container_tool", "podman", "--container_build_args", build_args]
     opence._main(arg_strings)
+

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -134,7 +134,7 @@ def test_channel_update_in_conda_env(mocker):
 
     channel_index_before, _ = get_channel_being_modified("tests/test-conda-env.yaml")
 
-    arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env-runtime.yaml"]
+    arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env.yaml"]
     opence._main(arg_strings)
 
     # We copy conda environment file to the passed local conda channel before updating it

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -16,6 +16,7 @@
 
 import os
 import pathlib
+import yaml
 import pytest
 from importlib.util import spec_from_loader, module_from_spec
 from importlib.machinery import SourceFileLoader 

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -99,7 +99,50 @@ def test_local_conda_channel_with_absolute_path(mocker):
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env.yaml"]
     opence._main(arg_strings)
 
-def test_for_failed_docker_build_cmd(mocker):
+def get_channel_being_modified(conda_env_file):
+    with open(conda_env_file, 'r') as file_handle:
+        env_info = yaml.safe_load(file_handle)
+
+    channels = env_info['channels']
+    channel_index = 0
+    channel_being_modified = ""
+    for channel in channels:
+        if channel.startswith("file:"):
+            channel_index = channels.index(channel)
+            channel_being_modified = channel
+            break
+
+    return channel_index, channel_being_modified
+
+def test_channel_update_in_conda_env(mocker):
+    '''
+    Test to see if channel is being updated in the conda env file before passing to build_runtime_image
+    '''
+
+    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
+
+    mocker.patch(
+        'os.system',
+        return_value=0,
+        side_effect=(lambda x: helpers.validate_cli(x, expect=["docker build",
+                                                               "-t " + intended_image_name])))
+    mocker.patch(
+        'os.remove',
+        return_value=0
+    )
+
+    channel_index_before, _ = get_channel_being_modified("tests/test-conda-env.yaml")
+
+    arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env-runtime.yaml"]
+    opence._main(arg_strings)
+
+    # We copy conda environment file to the passed local conda channel before updating it
+    channel_index_after, channel_modified = get_channel_being_modified("tests/testcondabuild/test-conda-env-runtime.yaml")
+
+    assert channel_modified == "file:/{}".format(build_image.TARGET_DIR)
+    assert channel_index_before == channel_index_after
+
+def test_for_failed_container_build_cmd(mocker):
     '''
     Simple test for build_runtime_image being failed due to some error in building the image
     '''

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -44,8 +44,7 @@ def test_build_image_positive_case(mocker):
                                                                "-t " + intended_image_name])))
 
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", "tests/testcondabuild", "--conda_env_file", "tests/test-conda-env.yaml"]
-    opence._main(arg_strings)
-    os.remove("tests/testcondabuild/test-conda-env.yaml")
+    open_ce._main(arg_strings)
 
 def test_not_existing_local_conda_channel():
     '''
@@ -99,8 +98,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
                                                                "-t " + intended_image_name])))
 
     arg_strings = ["build", build_image.COMMAND, "--local_conda_channel", os.path.join(test_dir, "testcondabuild"), "--conda_env_file", "tests/test-conda-env.yaml"]
-    opence._main(arg_strings)
-    os.remove("tests/testcondabuild/test-conda-env.yaml")
+    open_ce._main(arg_strings)
 
 def get_channel_being_modified(conda_env_file):
     with open(conda_env_file, 'r') as file_handle:
@@ -141,9 +139,6 @@ def test_channel_update_in_conda_env(mocker):
     assert channel_modified == "file:/{}".format(build_image.TARGET_DIR)
     assert channel_index_before == channel_index_after
 
-    # Cleanup
-    os.remove("tests/testcondabuild/test-conda-env.yaml") 
-
 def test_for_failed_docker_build_cmd(mocker):
     '''
     Simple test for build_runtime_image being failed due to some error in building the image
@@ -154,5 +149,3 @@ def test_for_failed_docker_build_cmd(mocker):
     with pytest.raises(OpenCEError) as exc:
         opence._main(arg_strings)
     assert "Failure building image" in str(exc.value)
-
-    os.remove("tests/testcondabuild/test-conda-env.yaml")


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR enables GPUs in the runtime DockerFile when using nvidia-container-runtime.
This also makes the conda env file consumption optional and more robust.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
