### PR TITLE
Improve copyrights

### DIFF
--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
+      - name: Ensure open-ce can load without conda-build
+        shell: bash -l {0}
+        run: |
+          ./open-ce/open-ce/open-ce -h
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Ensure open-ce can load without conda-build
         shell: bash -l {0}
         run: |
-          ./open-ce/open-ce/open-ce -h
+          ./open-ce/open-ce -h
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Ensure open-ce can load without conda-build
         shell: bash -l {0}
         run: |
+          conda install -y pyyaml requests
           ./open-ce/open-ce -h
       - name: Install dependencies
         shell: bash -l {0}

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -228,8 +228,8 @@ class LicenseGenerator():
                                                 _get_copyrights_from_conda_package(meta_data["extracted_package_dir"]))
             self._licenses.add(info)
 
-        #if os.path.exists(utils.TMP_LICENSE_DIR):
-        #    shutil.rmtree(utils.TMP_LICENSE_DIR)
+        if os.path.exists(utils.TMP_LICENSE_DIR):
+            shutil.rmtree(utils.TMP_LICENSE_DIR)
 
 def _get_copyrights_from_conda_package(pkg_dir):
     """

--- a/open-ce/get_licenses.py
+++ b/open-ce/get_licenses.py
@@ -28,12 +28,10 @@ import urllib.parse
 
 import requests
 import yaml
-import conda_build.source
 
 import utils
 from errors import OpenCEError, Error
 from inputs import Argument
-import conda_utils
 
 COMMAND = 'licenses'
 
@@ -151,7 +149,7 @@ class LicenseGenerator():
             if not os.path.exists(source_folder):
                 os.makedirs(source_folder)
 
-                urls = package[Key.license_url.name] if Key.license_url.name in package else package[Key.url.name]
+                urls = [package[Key.license_url.name]] if Key.license_url.name in package else package[Key.url.name]
 
                 # Download the source from each URL
                 for url in urls:
@@ -264,6 +262,8 @@ def _get_source_from_conda_package(pkg_dir):
     """
     Download the source for a conda package
     """
+    #pylint: disable=import-outside-toplevel
+    import conda_build.source
     source_folder = os.path.join(utils.TMP_LICENSE_DIR, os.path.basename(pkg_dir))
     if not os.path.exists(source_folder):
         os.makedirs(source_folder)
@@ -291,7 +291,7 @@ def _get_source_from_conda_package(pkg_dir):
                 git_url = source["git_url"]
                 try:
                     utils.git_clone(git_url, source.get("git_rev"), source_folder)
-                except OpenCEError as e:
+                except OpenCEError as error:
                     try:
                         # If the URL is from a private GIT server, try and use an equivalent URL on GitHub
                         parsed_url = urllib.parse.urlsplit(git_url)
@@ -302,7 +302,7 @@ def _get_source_from_conda_package(pkg_dir):
                             git_url = urllib.parse.urlunsplit(parsed_url)
                             utils.git_clone(git_url, source.get("git_rev"), source_folder)
                         else:
-                            raise e
+                            raise error
                     except OpenCEError:
                         print("Unable to clone source for " + os.path.basename(pkg_dir))
 

--- a/open-ce/validate_config.py
+++ b/open-ce/validate_config.py
@@ -71,7 +71,6 @@ def validate_build_tree(build_commands, external_deps, package_indices=None):
     channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels})
 
     cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
-    print(cli)
     ret_code, std_out, std_err = utils.run_command_capture(cli)
     if not ret_code:
         raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)

--- a/open-ce/validate_config.py
+++ b/open-ce/validate_config.py
@@ -71,6 +71,7 @@ def validate_build_tree(build_commands, external_deps, package_indices=None):
     channel_args = " ".join({"-c \"{}\"".format(channel) for channel in channels})
 
     cli = "conda create --dry-run -n test_conda_dependencies {} {}".format(channel_args, pkg_args)
+    print(cli)
     ret_code, std_out, std_err = utils.run_command_capture(cli)
     if not ret_code:
         raise OpenCEError(Error.VALIDATE_BUILD_TREE, cli, std_out, std_err)

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -36,7 +36,7 @@ def test_get_licenses(capsys):
     open_ce._main(["get", get_licenses.COMMAND, "--conda_env_file", "tests/test-conda-env3.yaml", "--output_folder", output_folder])
 
     captured = capsys.readouterr()
-    assert "Unable to clone source for libopus-1.3.1" in captured.out
+    assert "Unable to download source for icu-58.2" in captured.out
 
     output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
@@ -45,6 +45,7 @@ def test_get_licenses(capsys):
 
     print(license_contents)
     assert "pytest	6.2.2	https://github.com/pytest-dev/pytest/	MIT" in license_contents
+    assert "libopus	1.3.1	http://opus-codec.org/development/	3-clause BSD	Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo" in license_contents
 
     shutil.rmtree(output_folder)
 

--- a/tests/get_licenses_test.py
+++ b/tests/get_licenses_test.py
@@ -37,7 +37,6 @@ def test_get_licenses(capsys):
 
     captured = capsys.readouterr()
     assert "Unable to clone source for libopus-1.3.1" in captured.out
-    assert "Unable to download source for icu-58.2" in captured.out
 
     output_file = os.path.join(output_folder, utils.DEFAULT_LICENSES_FILE)
     assert os.path.exists(output_file)
@@ -130,3 +129,8 @@ def test_no_info_file():
     assert license_contents == ""
 
     shutil.rmtree(output_folder)
+
+def test_clean_copyright_string():
+    assert get_licenses._clean_copyright_string("// Not a Copyright 2020    ") == "Copyright 2020"
+    assert get_licenses._clean_copyright_string("// Not a Copyright 2020    ", primary=False) == "Not a Copyright 2020"
+    assert get_licenses._clean_copyright_string("// -------------") == ""


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR cleans up the `open-ce get licenses` command by:
1. Adding more values to `COPYRIGHT_STRINGS` and `EXCLUDE_STRINGS`.
1. Removing duplicate copyrights.
1. Checking the next line for copyrights if a copyright string ends with a value in `CONNECTOR_STRINGS`.
1. Searches for license files within a packages info directory if it was created from a wheel file.
1. Looks for source within github if a package's source was originally from a private git repository.

This PR also makes it so that it isn't required for conda-build to be installed to use other open-ce commands (although it is required when using `open-ce get licenses`. It also adds a test to verify that this will always be the case going forward.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
