### PR TITLE
Updated pylint to 2.7 and fixed corresponding new errors

### DIFF
--- a/.github/workflows/builder-unit-test.yml
+++ b/.github/workflows/builder-unit-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          conda install -y pylint=2.6.0 \
+          conda install -y pylint=2.7 \
                            conda-build \
                            pytest=6.0.1 \
                            pytest-cov=2.10.1 \

--- a/open_ce/build_env.py
+++ b/open_ce/build_env.py
@@ -69,8 +69,8 @@ def _run_tests(build_tree, test_labels, conda_env_files):
         raise OpenCEError(Error.FAILED_TESTS, len(failed_tests))
 
 def _all_outputs_exist(output_folder, output_files):
-    return all([os.path.exists(os.path.join(os.path.abspath(output_folder), package))
-                    for package in output_files])
+    return all((os.path.exists(os.path.join(os.path.abspath(output_folder), package))
+                    for package in output_files))
 
 def build_env(args):
     '''Entry Function'''

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -118,7 +118,7 @@ class BuildCommand():
     def __eq__(self, other):
         if not isinstance(other, BuildCommand):
             return False
-        return self.__key() == other.__key()  # pylint: disable=protected-access 
+        return self.__key() == other.__key()  # pylint: disable=protected-access
 
 def traverse_build_commands(commands, deps):
     """


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes #341.

After upgrading pylint to 2.7.x, most of the pylint errors are `invalid-name` pointing to the Enum keys we have defined in env_config.py, test_feedstock.py or get_licenses.py. I think changing all those keys everywhere will also need us change the environment files. So, I think we should add this error to the exception list. My PR for #329 has already added it in exception list (disabled in .pylintrc) as it was complaining for `invalid name` of `open-ce` binary file.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
