### PR TITLE
Allow list of conda_env_files to be passed in to tools

### DIFF
--- a/doc/README.open_ce_build.md
+++ b/doc/README.open_ce_build.md
@@ -309,7 +309,7 @@ So, the ideal sequence of getting Open-CE packages built and installed in a cont
 ```shell
 ==============================================================================
 usage: open-ce build image [-h] [--local_conda_channel LOCAL_CONDA_CHANNEL]
-                      [--conda_env_file CONDA_ENV_FILE]
+                           [--conda_env_files CONDA_ENV_FILES]
 
 Run Open-CE tools within a container
 
@@ -318,8 +318,9 @@ optional arguments:
   --local_conda_channel LOCAL_CONDA_CHANNEL
                         Path where built conda packages are present. (default:
                         condabuild)
-  --conda_env_file CONDA_ENV_FILE
-                        Location of conda environment file. (default: None)
+  --conda_env_files CONDA_ENV_FILES
+                        Comma delimited list of paths to conda environment
+                        files. (default: None)
 
 ==============================================================================
 ```

--- a/doc/README.open_ce_test.md
+++ b/doc/README.open_ce_test.md
@@ -145,18 +145,22 @@ The `open-ce test feedstock` command can be used to run tests for a specific fee
 
 ```shell
 ==============================================================================
-usage: open-ce test feedstock [-h] [--conda_env_file CONDA_ENV_FILE]
+usage: open-ce test feedstock [-h] [--conda_env_files CONDA_ENV_FILES]
                               [--test_working_dir TEST_WORKING_DIR]
                               [--test_labels TEST_LABELS]
+                              [--working_directory WORKING_DIRECTORY]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --conda_env_file CONDA_ENV_FILE
-                        Location of conda environment file. (default: None)
+  --conda_env_files CONDA_ENV_FILES
+                        Comma delimited list of paths to conda environment
+                        files. (default: None)
   --test_working_dir TEST_WORKING_DIR
                         Directory where tests will be executed. (default: ./)
   --test_labels TEST_LABELS
                         Comma delimited list of labels indicating what tests
                         to run. (default: )
+  --working_directory WORKING_DIRECTORY
+                        Directory to run the script in. (default: None)
 ==============================================================================
 ```

--- a/open_ce/get_licenses.py
+++ b/open_ce/get_licenses.py
@@ -31,7 +31,7 @@ import yaml
 
 from open_ce import utils
 from open_ce.errors import OpenCEError, Error
-from open_ce.inputs import Argument
+from open_ce.inputs import Argument, parse_arg_list
 
 COMMAND = 'licenses'
 
@@ -414,11 +414,14 @@ def get_licenses(args):
     """
     Entry point for `get licenses`.
     """
-    if not args.conda_env_file:
+    if not args.conda_env_files:
         raise OpenCEError(Error.CONDA_ENV_FILE_REQUIRED)
 
     gen = LicenseGenerator()
-    gen.add_licenses(args.conda_env_file)
+
+    for conda_env_file in parse_arg_list(args.conda_env_files):
+        gen.add_licenses(conda_env_file)
+
     gen.write_licenses_file(args.output_folder)
 
 ENTRY_FUNCTION = get_licenses

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -128,9 +128,9 @@ https://github.com/open-ce/open-ce/blob/main/doc/README.yaml.md"""))
                                         help="Run Open-CE tests for each potential conda environment"))
 
     CONDA_ENV_FILE = (lambda parser: parser.add_argument(
-                                        '--conda_env_file',
+                                        '--conda_env_files',
                                         type=str,
-                                        help='Location of conda environment file.' ))
+                                        help='Comma delimited list of paths to conda environment files.' ))
 
     LOCAL_CONDA_CHANNEL = (lambda parser: parser.add_argument(
                                         '--local_conda_channel',

--- a/open_ce/test_feedstock.py
+++ b/open_ce/test_feedstock.py
@@ -274,12 +274,16 @@ def test_feedstock(conda_env_file, test_labels=None,
 
 def test_feedstock_entry(args):
     '''Entry Function'''
-    if not args.conda_env_file:
+    if not args.conda_env_files:
         raise OpenCEError(Error.CONDA_ENV_FILE_REQUIRED)
-    test_failures = test_feedstock(args.conda_env_file,
-                                   args.test_labels,
-                                   args.test_working_dir,
-                                   args.working_directory)
+
+    test_failures = []
+    for conda_env_file in inputs.parse_arg_list(args.conda_env_files):
+        test_failures += test_feedstock(conda_env_file,
+                                       args.test_labels,
+                                       args.test_working_dir,
+                                       args.working_directory)
+
     if test_failures:
         display_failed_tests(test_failures)
         raise OpenCEError(Error.FAILED_TESTS, len(test_failures))


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [x] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description
Allow multiple conda environment files to be passed in to the tools through the `--conda_env_files` argument. Note, this shouldn't break previous behavior, since `--conda_env_file` can be used as shorthand for `--conda_env_files`.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
