### PR TITLE
use conda_env_file name in build image name

### DIFF
--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -34,7 +34,6 @@ OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
 RUNTIME_IMAGE_NAME = "opence-runtime"
 RUNTIME_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images", RUNTIME_IMAGE_NAME)
 REPO_NAME = "open-ce"
-IMAGE_NAME = "open-ce-runtime"
 BUILD_CONTEXT = "."
 
 OPENCE_USER = "opence"
@@ -47,7 +46,7 @@ def build_image(local_conda_channel, conda_env_file, container_tool, container_b
     Returns a result code and the name of the new image.
     """
     variant =  os.path.splitext(conda_env_file)[0].replace(utils.CONDA_ENV_FILENAME_PREFIX,"",1)
-    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + variant + "-" + str(os.getuid())
+    image_name = REPO_NAME + ":" + variant
     build_cmd = container_tool + " build "
     build_cmd += "-f " + os.path.join(RUNTIME_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -20,6 +20,7 @@
 import os
 import shutil
 from open_ce import utils
+from open_ce import __version__ as open_ce_version
 from open_ce.inputs import Argument, parse_arg_list
 from open_ce.errors import OpenCEError, Error
 
@@ -34,6 +35,7 @@ OPEN_CE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "."))
 RUNTIME_IMAGE_NAME = "opence-runtime"
 RUNTIME_IMAGE_PATH = os.path.join(OPEN_CE_PATH, "images", RUNTIME_IMAGE_NAME)
 REPO_NAME = "open-ce"
+IMAGE_NAME = "open-ce-" + open_ce_version
 BUILD_CONTEXT = "."
 
 OPENCE_USER = "opence"
@@ -46,7 +48,7 @@ def build_image(local_conda_channel, conda_env_file, container_tool, container_b
     Returns a result code and the name of the new image.
     """
     variant =  os.path.splitext(conda_env_file)[0].replace(utils.CONDA_ENV_FILENAME_PREFIX,"",1)
-    image_name = REPO_NAME + ":" + variant
+    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + variant
     build_cmd = container_tool + " build "
     build_cmd += "-f " + os.path.join(RUNTIME_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -46,7 +46,8 @@ def build_image(local_conda_channel, conda_env_file, container_tool, container_b
     Build a container image from the Dockerfile in RUNTIME_IMAGE_PATH.
     Returns a result code and the name of the new image.
     """
-    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + os.path.splitext(conda_env_file)[0] + "-" + str(os.getuid())
+    variant =  os.path.splitext(conda_env_file)[0].replace(utils.CONDA_ENV_FILENAME_PREFIX,"",1)
+    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + variant + "-" + str(os.getuid())
     build_cmd = container_tool + " build "
     build_cmd += "-f " + os.path.join(RUNTIME_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "

--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -46,7 +46,7 @@ def build_image(local_conda_channel, conda_env_file, container_tool, container_b
     Build a container image from the Dockerfile in RUNTIME_IMAGE_PATH.
     Returns a result code and the name of the new image.
     """
-    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + str(os.getuid())
+    image_name = REPO_NAME + ":" + IMAGE_NAME + "-" + os.path.splitext(conda_env_file)[0] + "-" + str(os.getuid())
     build_cmd = container_tool + " build "
     build_cmd += "-f " + os.path.join(RUNTIME_IMAGE_PATH, "Dockerfile") + " "
     build_cmd += "-t " + image_name + " "

--- a/open_ce/container_build.py
+++ b/open_ce/container_build.py
@@ -57,9 +57,9 @@ def build_image(build_image_path, dockerfile, container_tool, cuda_version=None,
     Returns a result code and the name of the new image.
     """
     if cuda_version:
-        image_name = REPO_NAME + ":" + IMAGE_NAME + "-cuda" + cuda_version + "-" + str(os.getuid())
+        image_name = REPO_NAME + ":" + IMAGE_NAME + "-cuda" + cuda_version
     else:
-        image_name = REPO_NAME + ":" + IMAGE_NAME + "-cpu-" + str(os.getuid())
+        image_name = REPO_NAME + ":" + IMAGE_NAME + "-cpu"
     build_cmd = container_tool + " build "
     build_cmd += "-f " + dockerfile + " "
     build_cmd += "-t " + image_name + " "

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -36,7 +36,7 @@ def test_build_image_positive_case(mocker):
     '''
     Simple test for build_runtime_image
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
+    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
     container_tool = utils.DEFAULT_CONTAINER_TOOL
 
     mocker.patch(
@@ -91,7 +91,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
     '''
     Test for build_runtime_image with local conda channel with its absolute path
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
+    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -122,7 +122,7 @@ def test_channel_update_in_conda_env(mocker):
     Test to see if channel is being updated in the conda env file before passing to build_runtime_image
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
+    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -161,7 +161,7 @@ def test_modified_file_removed(mocker):
     Make sure the copied conda env file was deleted afterwards
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
+    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -36,7 +36,7 @@ def test_build_image_positive_case(mocker):
     '''
     Simple test for build_runtime_image
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
+    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
     container_tool = utils.DEFAULT_CONTAINER_TOOL
 
     mocker.patch(
@@ -91,7 +91,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
     '''
     Test for build_runtime_image with local conda channel with its absolute path
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
+    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -122,7 +122,7 @@ def test_channel_update_in_conda_env(mocker):
     Test to see if channel is being updated in the conda env file before passing to build_runtime_image
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
+    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -161,7 +161,7 @@ def test_modified_file_removed(mocker):
     Make sure the copied conda env file was deleted afterwards
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + "test-conda-env"
+    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',

--- a/tests/build_image_test.py
+++ b/tests/build_image_test.py
@@ -36,7 +36,7 @@ def test_build_image_positive_case(mocker):
     '''
     Simple test for build_runtime_image
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
+    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
     container_tool = utils.DEFAULT_CONTAINER_TOOL
 
     mocker.patch(
@@ -91,7 +91,7 @@ def test_local_conda_channel_with_absolute_path(mocker):
     '''
     Test for build_runtime_image with local conda channel with its absolute path
     '''
-    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
+    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -122,7 +122,7 @@ def test_channel_update_in_conda_env(mocker):
     Test to see if channel is being updated in the conda env file before passing to build_runtime_image
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
+    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',
@@ -161,7 +161,7 @@ def test_modified_file_removed(mocker):
     Make sure the copied conda env file was deleted afterwards
     '''
 
-    intended_image_name = build_image.REPO_NAME + ":" + build_image.IMAGE_NAME
+    intended_image_name = build_image.REPO_NAME + ":" + os.path.splitext("test-conda-env.yaml")[0]
     container_tool = utils.DEFAULT_CONTAINER_TOOL
     mocker.patch(
         'os.system',

--- a/tests/container_build_test.py
+++ b/tests/container_build_test.py
@@ -36,7 +36,7 @@ def test_build_image(mocker):
     #CUDA build
     cuda_version="11.0"
     container_tool = "docker"
-    intended_image_name = container_build.REPO_NAME + ":" + container_build.IMAGE_NAME + "-cuda" + cuda_version + "-1234"
+    intended_image_name = container_build.REPO_NAME + ":" + container_build.IMAGE_NAME + "-cuda" + cuda_version
 
     mocker.patch(
         'os.system',
@@ -47,7 +47,7 @@ def test_build_image(mocker):
     assert container_build.build_image("test", "test", container_tool, cuda_version) == intended_image_name
 
     #CPU build  
-    intended_image_name = container_build.REPO_NAME + ":" + container_build.IMAGE_NAME + "-cpu" + "-1234"
+    intended_image_name = container_build.REPO_NAME + ":" + container_build.IMAGE_NAME + "-cpu"
 
     mocker.patch(
         'os.system',


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Use conda_env_file name in the image_name to avoid creating images with `<none>` tag when multiple conda_env_files are given. 

Also updated to use compact image names and added opence version in the image name. 

Eg. image name:
`localhost/open-ce                    open-ce-1.1.3-py3.7-cpu-openmpi-10.2`

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
