### PR TITLE
fix env file not found error

### DIFF
--- a/open_ce/build_image.py
+++ b/open_ce/build_image.py
@@ -101,7 +101,7 @@ def build_runtime_container_image(args):
             # make it relative to BUILD CONTEXT
             args.local_conda_channel = os.path.relpath(args.local_conda_channel, start=BUILD_CONTEXT)
 
-        image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_file),
+        image_name = build_image(args.local_conda_channel, os.path.basename(conda_env_runtime_file),
                                  args.container_tool, args.container_build_args)
 
         # Remove the copied environment file


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Fixes the below error observed while building run time image. 

```
STEP 21: RUN if [ -n "$CONDA_ENV_FILE" ]; then $CONDA_HOME/bin/conda env create -f ${TARGET_DIR}/${CONDA_ENV_FILE}; fi

EnvironmentFileNotFound: '/home/opence/opence-local-conda-channel/opence-conda-env-py3.7-cpu-openmpi-10.2.yaml' file not found

Error: error building at STEP "RUN if [ -n "$CONDA_ENV_FILE" ]; then $CONDA_HOME/bin/conda env create -f ${TARGET_DIR}/${CONDA_ENV_FILE}; fi": error while running runtime: exit status 1
[OPEN-CE-ERROR-5] Failure building image: "open-ce:open-ce-1.1.3-py3.7-cpu-openmpi-10.2"
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
