### PR TITLE
Create an all_outputs_exist method in BuildCommand

### DIFF
--- a/open_ce/build_env.py
+++ b/open_ce/build_env.py
@@ -77,10 +77,6 @@ def _run_tests(build_tree, test_labels, conda_env_files):
     if failed_tests:
         raise OpenCEError(Error.FAILED_TESTS, len(failed_tests))
 
-def _all_outputs_exist(output_folder, output_files):
-    return all((os.path.exists(os.path.join(os.path.abspath(output_folder), package))
-                    for package in output_files))
-
 def build_env(args):
     '''Entry Function'''
 
@@ -136,7 +132,7 @@ def build_env(args):
     if not args.skip_build_packages:
         # Build each package in the packages list
         for build_command in build_tree:
-            if not _all_outputs_exist(args.output_folder, build_command.output_files):
+            if not build_command.all_outputs_exist(args.output_folder):
                 try:
                     print("Building " + build_command.recipe)
                     build_feedstock.build_feedstock_from_command(build_command,

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -108,6 +108,12 @@ class BuildCommand():
         result = result.replace("_", "-")
         return result
 
+    def all_outputs_exist(self, output_folder):
+        """
+        Returns true if all of the output_files already exist.
+        """
+        return all((os.path.exists(os.path.join(os.path.abspath(output_folder), package))
+                    for package in self.output_files))
 
     def __key(self):
         return (self.recipe, self.output_files)

--- a/tests/build_env_test.py
+++ b/tests/build_env_test.py
@@ -162,7 +162,7 @@ def test_build_env(mocker, capsys):
 
     #---The fourth test verifies that builds are skipped properly if they already exist.
     mocker.patch(
-        'open_ce.build_env._all_outputs_exist',
+        'open_ce.build_tree.BuildCommand.all_outputs_exist',
         return_value=True)
 
     captured = capsys.readouterr()
@@ -170,7 +170,7 @@ def test_build_env(mocker, capsys):
     captured = capsys.readouterr()
     assert "Skipping build of" in captured.out
     mocker.patch(
-        'open_ce.build_env._all_outputs_exist',
+        'open_ce.build_tree.BuildCommand.all_outputs_exist',
         return_value=False)
 
     #---The fifth test specifies a cuda version that isn't supported in the env file by package21.


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Cleans up the BuildCommand interface a little bit by adding an `all_outputs_exists` method.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
