### PR TITLE
Add the git_up_to_date option

### DIFF
--- a/open_ce/build_env.py
+++ b/open_ce/build_env.py
@@ -48,6 +48,7 @@ ARGUMENTS = [Argument.CONDA_BUILD_CONFIG,
              Argument.CONTAINER_BUILD,
              Argument.GIT_LOCATION,
              Argument.GIT_TAG_FOR_ENV,
+             Argument.GIT_UP_TO_DATE,
              Argument.TEST_LABELS,
              Argument.CONTAINER_BUILD_ARGS,
              Argument.CONTAINER_TOOL]
@@ -119,6 +120,7 @@ def build_env(args):
                                channels=args.channels_list,
                                git_location=args.git_location,
                                git_tag_for_env=args.git_tag_for_env,
+                               git_up_to_date=args.git_up_to_date,
                                conda_build_config=args.conda_build_config,
                                packages=inputs.parse_arg_list(args.packages))
 

--- a/open_ce/build_tree.py
+++ b/open_ce/build_tree.py
@@ -310,6 +310,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
                  channels=None,
                  git_location=utils.DEFAULT_GIT_LOCATION,
                  git_tag_for_env=utils.DEFAULT_GIT_TAG,
+                 git_up_to_date=False,
                  conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG,
                  packages=None):
 
@@ -318,6 +319,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         self._channels = channels if channels else []
         self._git_location = git_location
         self._git_tag_for_env = git_tag_for_env
+        self._git_up_to_date = git_up_to_date
         self._conda_build_config = conda_build_config
         self._external_dependencies = dict()
         self._conda_env_files = dict()
@@ -445,6 +447,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
         # at all specified then fall back to default branch of the repo.
 
         git_tag = self._git_tag_for_env
+        git_tag_for_package = None
         if git_tag is None:
             git_tag_for_package = package.get(env_config.Key.git_tag.name, None) if package else None
             if git_tag_for_package:
@@ -452,7 +455,7 @@ class BuildTree(): #pylint: disable=too-many-instance-attributes
             else:
                 git_tag = env_config_data.get(env_config.Key.git_tag_for_env.name, None) if env_config_data else None
 
-        clone_successful = utils.git_clone(git_url, git_tag, repo_dir)
+        clone_successful = utils.git_clone(git_url, git_tag, repo_dir, self._git_up_to_date and not git_tag_for_package)
 
         if clone_successful:
             patches = package.get(env_config.Key.patches.name, []) if package else []

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -197,6 +197,11 @@ path of \"recipe\"."""))
                                         default=None,
                                         help='Git tag to be checked out for all of the packages in an environment.'))
 
+    GIT_UP_TO_DATE = (lambda parser: parser.add_argument(
+                                        '--git_up_to_date',
+                                        action='store_true',
+                                        help='Use the most recent commits from the branch that the provided tag is in.'))
+
     TEST_LABELS = (lambda parser: parser.add_argument(
                                         '--test_labels',
                                         type=str,

--- a/open_ce/inputs.py
+++ b/open_ce/inputs.py
@@ -197,10 +197,11 @@ path of \"recipe\"."""))
                                         default=None,
                                         help='Git tag to be checked out for all of the packages in an environment.'))
 
+    # Use the most recent commits from the branch that the provided tag is in.
     GIT_UP_TO_DATE = (lambda parser: parser.add_argument(
                                         '--git_up_to_date',
                                         action='store_true',
-                                        help='Use the most recent commits from the branch that the provided tag is in.'))
+                                        help=argparse.SUPPRESS))
 
     TEST_LABELS = (lambda parser: parser.add_argument(
                                         '--test_labels',

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -284,9 +284,7 @@ def _get_branch_of_tag(git_tag):
     possible_branches = output.splitlines()
 
     # Clean branches and sort so that highest release version number is last
-    print(possible_branches)
     possible_branches = [possible_branch.replace('*','').strip() for possible_branch in possible_branches]
-    print(possible_branches)
     possible_branches = list(filter(lambda x: x == "remotes/origin/main" or
                                x.startswith("remotes/origin/r"), sorted(possible_branches)))
 

--- a/open_ce/utils.py
+++ b/open_ce/utils.py
@@ -273,7 +273,19 @@ def replace_conda_env_channels(conda_env_file, original_channel, new_channel):
     with open(conda_env_file, 'w') as file_handle:
         yaml.safe_dump(env_info, file_handle)
 
-def git_clone(git_url, git_tag, location):
+def _get_up_to_date_branch(git_tag):
+    branch_command = "git branch -a --contains " + git_tag
+    ret_code, output, _ = run_command_capture(branch_command)
+    if not ret_code or not output:
+        return git_tag
+    possible_branches = output.splitlines()
+    # Clean branches
+    possible_branches = filter(lambda x: not "->" in x, possible_branches)
+    possible_branches = [possible_branch.replace('*','').strip() for possible_branch in possible_branches]
+
+    return possible_branches[-1]
+
+def git_clone(git_url, git_tag, location, up_to_date=False):
     '''
     Clone a git repository and checkout a certain branch.
     '''
@@ -284,8 +296,10 @@ def git_clone(git_url, git_tag, location):
     cur_dir = os.getcwd()
     clone_successful = clone_result == 0
     if clone_successful:
-        if not git_tag is None:
+        if git_tag:
             os.chdir(location)
+            if up_to_date:
+                git_tag = _get_up_to_date_branch(git_tag)
             checkout_cmd = "git checkout " + git_tag
             print("Checkout branch/tag command: ", checkout_cmd)
             checkout_res = os.system(checkout_cmd)

--- a/tests/build_tree_test.py
+++ b/tests/build_tree_test.py
@@ -38,11 +38,13 @@ class TestBuildTree(build_tree.BuildTree):
                  repository_folder="./",
                  git_location=utils.DEFAULT_GIT_LOCATION,
                  git_tag_for_env=utils.DEFAULT_GIT_TAG,
+                 git_up_to_date = False,
                  conda_build_config=utils.DEFAULT_CONDA_BUILD_CONFIG):
         self._env_config_files = env_config_files
         self._repository_folder = repository_folder
         self._git_location = git_location
         self._git_tag_for_env = git_tag_for_env
+        self._git_up_to_date = git_up_to_date
         self._conda_build_config = conda_build_config
         self._possible_variants = utils.make_variants(python_versions, build_types, mpi_types, cuda_versions)
         self._test_feedstocks = dict()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -122,4 +122,16 @@ def test_cuda_driver_installed_failures(mocker):
     mocker.patch('subprocess.check_output',side_effect=OSError(errno.EPERM,"" ))
     with pytest.raises(OpenCEError) as exc:
         utils.cuda_driver_installed()
-    assert "lsmod command unexpectedly failed" in str(exc.value)    
+    assert "lsmod command unexpectedly failed" in str(exc.value)
+
+def test_get_branch_of_tag(mocker):
+    '''
+    Simple tests for the get_up_to_date_branch
+    '''
+    sample_output = "main\n  remotes/origin/main\n* remotes/origin/r2.4.1   \n"
+    mocker.patch('open_ce.utils.run_command_capture', side_effect=[(True, sample_output, ""), (False, sample_output, "")])
+
+    assert utils._get_branch_of_tag("mytag") == "remotes/origin/r2.4.1"
+
+    assert utils._get_branch_of_tag("mytag") == "mytag"
+


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR adds the `--git_up_to_date` option to `open-ce build env`.

The purpose of this option is allow fo building on top of a release of an open-ce environment. When this option is enabled it will:
* Find every branch that a provided git_tag is in for a feedstock.
* Checkout the branch that the provided git tag is in.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
