### PR TITLE
only validate against opence-env.yaml

### DIFF
--- a/.github/actions/feedstock-required-pr/action.yml
+++ b/.github/actions/feedstock-required-pr/action.yml
@@ -18,7 +18,7 @@ runs:
         env_path="$GITHUB_ACTION_PATH/../../../envs"
         pip install git+https://github.com/open-ce/open-ce-builder.git@main
         open-ce validate config \
-                         ${env_path}/*-env.yaml \
+                         ${env_path}/opence-env.yaml \
                          --build_types cuda,cpu \
                          --python_versions 3.6,3.7,3.8 \
                          --repository_folder ../

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -39,7 +39,7 @@ jobs:
           # Validate conda_build_config for the main open-ce env file.
           open-ce validate config --conda_build_config \
                                             ./envs/conda_build_config.yaml \
-                                            ./envs/*-env.yaml \
+                                            ./envs/opence-env.yaml \
                                             --python_versions 3.6,3.7,3.8 \
                                             --build_types cuda,cpu \
                                             --mpi_types openmpi,system


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

With Open-CE 1.2 we split Tensorboard into its own env file since it is not yet compatible with protobuf 3.11. (https://github.com/open-ce/open-ce/pull/381)
This adjusts the required validation github action for PRs that checks for a coherent environment

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
