### PR TITLE
Remove cmake recipe in lightgbm env for 1.1

### DIFF
--- a/envs/lightgbm-env.yaml
+++ b/envs/lightgbm-env.yaml
@@ -1,11 +1,5 @@
 packages:
   - feedstock : LightGBM
   - feedstock : openmpi          #[mpi_type == 'openmpi']
-  - feedstock : https://github.com/conda-forge/cmake-feedstock
-    git_tag : 26e3ecb4156c14d90a66fd1433d52a1d7e27946d
-    patches :
-      - ../feedstock-patches/cmake/0001-Fix-test.patch
-      - ../feedstock-patches/cmake/0002-set-rhash-version.patch
-    runtime_package : False
 
 git_tag_for_env: open-ce-v1.1.4


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

We no longer need to build cmake as cmake 3.19 is now available in defaults. This has also been causing some other issues so we can safely remove for the 1.1 stream.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
