### PR TITLE
[1.1] Copy conda_build_config into envs folder for newer builder

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -1,0 +1,249 @@
+absl_py:
+  - 0.10.*
+astunparse:
+  - 1.6
+attrs:
+  - 19
+autoconf:
+  - 2.69
+automake:
+  - 1.16
+av:
+  - 8.*
+bazel:
+  - 3.*
+boost:
+  - 1.67.0
+c_compiler_version:
+  - 7.2.*                      # [x86_64]
+  - 7.3.*                      # [ppc64le]
+catalogue:
+  - 1.0.0
+cffi:
+  - 1.14.*
+click:
+  - 7.*
+cloudpickle:
+  - 1.3.*
+cmake:
+  - 3.14.*
+coverage:
+  - 4.*
+cudnn:
+  - 7.6.5.*                    # [cudatoolkit == '10.2']
+  - 8.0.4.*                    # [cudatoolkit == '11.0']
+cxx_compiler_version:
+  - 7.2.*                      # [x86_64]
+  - 7.3.*                      # [ppc64le]
+cxxfilt:
+  - 0.2.*
+cymem:
+  - 2.0.*
+cython:
+  - 0.29
+cython_blis:
+  - 0.4.*
+dataclasses:
+  - 0.7
+dm_tree:
+  - 0.1.*
+eigen:
+  - 3.3.7
+ffmpeg:
+  - 4.2.*
+flatbuffers:
+  - 1.12.*
+freetype:
+  - 2
+fortran_compiler_version:
+  - 7.2.*                      # [x86_64]
+  - 7.3.*                      # [ppc64le]
+fsspec:
+  - 0.8.*
+future:
+  - 0.18.*
+gast:
+  - 0.3.3
+git:
+  - 2.2
+google_auth:
+  - 1.23.*
+google_auth_oauthlib:
+  - 0.4.*
+google_pasta:
+  - 0.2
+googleapis_common_protos:
+  - 1.52.*
+graphsurgeon:
+  - 0.4.1                     # [cudatoolkit == '10.2']
+  - 0.4.5                     # [cudatoolkit == '11.0']
+grpcio:
+  - 1.31.*
+harfbuzz:
+  - 1.8
+# Note: hdf5 version must be compatible with h5py
+hdf5:
+  - 1.10.4
+hypothesis:
+  - 5.*
+h5py:
+  - 2.10.0
+importlib_resources:
+  - 3.3.0
+jasper:
+  - 2.0.14
+joblib:
+  - 0.17
+jpeg:
+  - 9b
+jpegturbo:
+  - 2.0.5
+keras_applications:
+  - 1.0.8
+keras_preprocessing:
+  - 1.1.*
+leveldb:
+  - 1.20.*
+libevent:
+  - 2.1.*
+libgfortran:
+  - 7.2.*                      # [x86_64]
+  - 7.3.*                      # [ppc64le]
+libogg:
+  - 1.3.*
+libpng:
+  - 1.6
+libtiff:
+  - 4.1
+libtool:
+  - 2.4.6
+lmdb:
+  - 0.9.22.*
+magma:
+  - 2.5.4.*
+make:
+  - 4.2.1
+markdown:
+  - 3.1
+mock:
+  - 3.*
+murmurhash:
+  - 1.0.*
+nasm:                          # [x86_64]
+  - 2.13.03                    # [x86_64]
+networkx:
+  - 2.3.*
+ninja:
+  - 1.9.*
+nccl:
+  - 2.7.*
+numactl:
+  - 2.0.*
+numba:
+  - 0.47.*
+numpy:
+  - 1.19.*
+onnx:
+  - 1.6.*
+onnx_graphsurgeon:
+  - 0.2.*
+openblas:
+  - 0.3.6.*
+opencv:
+  - 3.4.10.*
+openjdk:
+  - 8.0.152                    # [x86_64]
+  - 1.8.0                      # [ppc64le]
+openmpi:
+  - 3.1.3
+opt_einsum:
+  - 3.1.0
+pillow:
+  - 8.*
+pip:
+  - 19*
+pkg_config:
+  - 0.29.2
+plac:
+  - 0.9.6
+preshed:
+  - 3.0.*
+protobuf:
+  - 3.9.*
+psutil:
+  - 5
+pytest:
+  - 5.*
+python:
+  - 3.6
+  - 3.7
+python_lmdb:
+  - 0.98.*
+pytorch:
+  - 1.7.*
+pytorch_lightning:
+  - 1.1.*
+pyyaml:
+  - 5.*
+requests:
+  - 2.22
+regex:
+  - 2020.6.*
+rust_nightly:
+  - 1.50.0
+scikit_image:
+  - 0.17
+scipy:
+  - 1.4.*
+sentencepiece:
+  - 0.1.91
+setuptools:
+  - 41.*
+setuptools_rust:
+  - 0.11.3
+six:
+  - 1.15.0
+srsly:
+  - 1.0.4
+tabulate:
+  - 0.8.*
+tensorboard:
+  - 2.4.*
+tensorboard_plugin_wit:
+  - 1.6
+tensorflow:
+  - 2.4.*
+tensorflow_hub:
+  - 0.10
+tensorrt:
+  - 7.0.*                    # [cudatoolkit == '10.2']
+  - 7.2.*                    # [cudatoolkit == '11.0']
+termcolor:
+  - 1.1.0
+thinc:
+  - 7.4.1
+tokenizers:
+  - 0.9.3
+torchtext:
+  - 0.8.*
+torchvision:
+  - 0.8.*
+tqdm:
+  - 4.*
+typing_extensions:
+  - 3.7.4.*
+uff:
+  - 0.6.5                    # [cudatoolkit == '10.2']
+  - 0.6.9                    # [cudatoolkit == '11.0']
+unzip:
+  - 6.0
+wasabi:
+  - 0.6.0
+werkzeug:
+  - 0.16.0
+wheel:
+  - 0.35*
+wrapt:
+  - 1.12.*
+zlib:
+  - 1.2.11


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

Newer open-ce-builder versions check for the conda_build_config.yaml to be in the same directory as the env files, so this PR makes a copy of the conda_build_config.yaml in the envs/ directory to support that. You can specify the location of this file for newer builders but this will allow newer builders to build the 1.1.x release without any 1.1.x specifics.
This just makes a copy since there may be things that are expecting the conda_build_config.yaml to be where it currently is. The downside is if there are any changes needed, it will require changes in both copies. This is deemed acceptable as we don't expect 1.1.x to change much more at this point.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
