### PR TITLE
[1.2.x] add pins for libgcc,libstdcxx

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -112,6 +112,12 @@ leveldb:
   - 1.20.*
 libevent:
   - 2.1.*
+libgcc:
+  - 9.1.*                      # [x86_64]
+  - 8.2.*                      # [ppc64le]
+libstdcxx:
+  - 9.1.*                      # [x86_64]
+  - 8.2.*                      # [ppc64le]
 libgfortran:
   - 7.2.*                      # [x86_64]
   - 7.3.*                      # [ppc64le]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description
Anaconda just updated toolchains and associated libraries. One of the changes is breaking out libgomp into its own library.
This PR addresses 1.2.x: let's pin to libraries before this change.
Subsequent patches will be needed for any feedstocks that use OpenMP to use these pins and arguably we should add them across the board to the host section of feedstocks.

Fixes #315 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
