### PR TITLE
Move recipe check first.

### DIFF
--- a/.github/actions/feedstock-required-pr/action.yml
+++ b/.github/actions/feedstock-required-pr/action.yml
@@ -12,21 +12,21 @@ runs:
       run: |
         conda install -y conda-build
         echo "env_path=$GITHUB_ACTION_PATH/../../../envs" >> $GITHUB_ENV
-    - name: Check Dependencies
-      shell: bash -l {0}
-      run: |
-        # Validate the open-ce env file
         git clone https://github.com/open-ce/open-ce-builder.git \
                   ./open-ce-builder
         pip install -e open-ce-builder
-        open-ce validate config \
-                         ${env_path}/*-env.yaml \
-                         --build_types cuda,cpu \
-                         --python_versions 3.6,3.7,3.8 \
-                         --repository_folder ../
     - name: Check recipes
       shell: bash -l {0}
       run: |
         python open-ce-builder/tests/feedstock_tests/check_recipes.py \
                --conda_build_config \
                "${env_path}/conda_build_config.yaml"
+    - name: Check Dependencies
+      shell: bash -l {0}
+      run: |
+        # Validate the open-ce env files
+        open-ce validate config \
+                         ${env_path}/*-env.yaml \
+                         --build_types cuda,cpu \
+                         --python_versions 3.6,3.7,3.8 \
+                         --repository_folder ../


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?

## Description

Move recipe check first in feedstock tests so that if there's a problem with the recipe it fails quicker.

Also move the builder install up into the installation step.
