### PR TITLE
Disabling DALI for 1.3

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -29,6 +29,8 @@ catalogue:
   - 2.*
 cffi:
   - 1.14.*
+clang:
+  - 10.0.*
 click:
   - 7.*
 cloudpickle:
@@ -209,8 +211,6 @@ pytest:
 python:
   - 3.6 # [not s390x]
   - 3.7
-python-clang:
-  - 10.0.*
 pytorch:
   - 1.8.*
 pytorch_lightning:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -209,6 +209,8 @@ pytest:
 python:
   - 3.6 # [not s390x]
   - 3.7
+python-clang:
+  - 10.0.*
 pytorch:
   - 1.8.*
 pytorch_lightning:

--- a/envs/dali-env.yaml
+++ b/envs/dali-env.yaml
@@ -1,13 +1,10 @@
 imported_envs:
-{% if x86_64 %}
-{% if build_type == 'cuda' %}
+{% if x86_64 and build_type == 'cuda' %}
   - tensorflow-env.yaml
-{% endif %}
 {% endif %}
 
 packages:
-{% if x86_64 %}
-{% if build_type == 'cuda' %}
+{% if x86_64 and build_type == 'cuda' %}
   - feedstock : cudatoolkit    #[cudatoolkit == "11.2"]
   - feedstock : opencv
   - feedstock : https://github.com/conda-forge/clangdev-feedstock     # [ppc64le]
@@ -18,5 +15,4 @@ packages:
   - feedstock : jpeg-turbo
   - feedstock : libflac
   - feedstock : libsndfile
-{% endif %}
 {% endif %}

--- a/envs/dali-env.yaml
+++ b/envs/dali-env.yaml
@@ -1,17 +1,17 @@
 imported_envs:
-{% if x86_64 and build_type == 'cuda' %}
+{% if build_type == 'cuda' %}
   - tensorflow-env.yaml
 {% endif %}
 
 packages:
-{% if x86_64 and build_type == 'cuda' %}
+{% if build_type == 'cuda' %}
   - feedstock : cudatoolkit    #[cudatoolkit == "11.2"]
   - feedstock : opencv
   - feedstock : https://github.com/conda-forge/clangdev-feedstock     # [ppc64le]
     git_tag: 98e30dba8b405a388d5b5d0fcca3834ee40b0b1c
     patches:
       - ../feedstock-patches/clangdev/pin_gcc_libs.patch
-  - feedstock : DALI
+  - feedstock : DALI  # [x86_64]
   - feedstock : jpeg-turbo
   - feedstock : libflac
   - feedstock : libsndfile

--- a/envs/dali-env.yaml
+++ b/envs/dali-env.yaml
@@ -1,9 +1,12 @@
 imported_envs:
+{% if x86_64 %}
 {% if build_type == 'cuda' %}
   - tensorflow-env.yaml
 {% endif %}
+{% endif %}
 
 packages:
+{% if x86_64 %}
 {% if build_type == 'cuda' %}
   - feedstock : cudatoolkit    #[cudatoolkit == "11.2"]
   - feedstock : opencv
@@ -15,4 +18,5 @@ packages:
   - feedstock : jpeg-turbo
   - feedstock : libflac
   - feedstock : libsndfile
+{% endif %}
 {% endif %}

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -4,7 +4,8 @@ imported_envs:
   - pytorch-extras-env.yaml
   - tensorflow-env.yaml
   - xgboost-env.yaml
-  - dali-env.yaml
+  # Disabling DALI for 1.3
+  #- dali-env.yaml
   - spacy-env.yaml
   - transformers-env.yaml
   - horovod-env.yaml

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -4,8 +4,8 @@ imported_envs:
   - pytorch-extras-env.yaml
   - tensorflow-env.yaml
   - xgboost-env.yaml
-  # Disabling DALI for 1.3
-  #- dali-env.yaml
+  # Disabling DALI for 1.3 on ppc64le
+  - dali-env.yaml    #[x86_64]
   - spacy-env.yaml
   - transformers-env.yaml
   - horovod-env.yaml


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Disabling DALI temporarily for 1.3 due to an error caused by gcc 8. 

GCC 8 (or newer) needed because of this patch (which is also upstream TF now):
open-ce/tensorflow-feedstock#55. And since TF is built using gcc8, DALI TF plugin fails to compile using gcc 7.3. And updating gcc to 8.2 for DALI leads to another error as mentioned here https://github.com/open-ce/DALI-feedstock/pull/31

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
