### PR TITLE
no uwsgi on py39

### DIFF
--- a/envs/uwsgi-env.yaml
+++ b/envs/uwsgi-env.yaml
@@ -1,7 +1,10 @@
 packages:
+{% set py_ver = python | float %}
+{% if py_ver < 3.9 %}
   - feedstock: https://github.com/conda-forge/jansson-feedstock
     git_tag: 5c2760222698c28ecf9d5608f94d9cdcaa2d9cb8  #2.13.1
   - feedstock: http://github.com/conda-forge/uwsgi-feedstock
     git_tag: 08daba6edd2eaf4f72876af6d18f9fdf18a44383  #2.0.19.1
     patches:
       - ../feedstock-patches/uwsgi/0001-disable-lto-adjust-pins.patch 
+{% endif %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

uwsgi has libpython issue on py39, x86. Likely due to the new anaconda toolchains
disable this on py39 for now.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
