### PR TITLE
make h5py pins compatible with hdf5

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -97,7 +97,8 @@ harfbuzz:
   - 1.8
 # Note: hdf5 version must be compatible with h5py
 hdf5:
-  - 1.10.4
+  - 1.10.4    # [ppc64le and py<39]
+  - 1.10.6    # [x86_64 or (ppc64le and py39)]
 hypothesis:
   - 5.*
 h5py:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Update `hdf5` pins so that these become compatible with `h5py`. 
The `h5py v2.10.0` has the following dependency on `hdf5`:

```
x86   
py36   - hdf5 >=1.10.6,<1.10.7.0a0
py37   - hdf5 >=1.10.6,<1.10.7.0a0
py38   - hdf5 >=1.10.6,<1.10.7.0a0
py39   - hdf5 >=1.10.6,<1.10.7.0a0

power:
py36:    - hdf5 >=1.10.4,<1.10.5.0a0
py37:    - hdf5 >=1.10.4,<1.10.5.0a0
py38:    - hdf5 >=1.10.4,<1.10.5.0a0
py39:    - hdf5 >=1.10.6,<1.10.7.0a0
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
