### PR TITLE
fix py39 selector for hdf5

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -98,7 +98,7 @@ harfbuzz:
 # Note: hdf5 version must be compatible with h5py
 hdf5:
   - 1.10.4    # [ppc64le and py<39]
-  - 1.10.6    # [x86_64 or (ppc64le and py39)]
+  - 1.10.6    # [x86_64 or (ppc64le and py==39)]
 hypothesis:
   - 5.*
 h5py:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes the following error observed while building OpenCV for py39:
```
Solving environment: ...working... done
Error: Failed to render jinja template in /home/builder/code-11aug/opencv-feedstock/recipe/meta.yaml:
'hdf5' is undefined
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
