### PR TITLE
use list of supported CUDA arch in cuda_levels_details

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -333,9 +333,9 @@ cuda_levels:
   - 3.7;5.2;6.0;7.0;7.5     # [x86_64]
   - 3.7;6.0;7.0;7.5         # [ppc64le]
 cuda_levels_details:
-  - sm_37,sm_52,sm_60,sm_61,sm_70,compute_75  # [x86_64]
-  - sm_37,sm_60,sm_70,compute_75              # [ppc64le]
+  - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,compute_75  # [x86_64]
+  - sm_37,sm_60,sm_70,sm_75,compute_75              # [ppc64le]
 cuda11_levels:
   - 8.0
 cuda11_levels_details:
-  - compute_80
+  - sm_80,compute_80

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -320,22 +320,22 @@ vector_settings:
 ##     - compute_<cuda_arch> : include PTX
 ##     - sm_<cuda_arch> : do not include PTX
 ## These are passed in to the build via the
-## `cuda_level_details` define
+## `cuda_level_details` define.
 ##
 ## Since CUBINs are compatible within the same major architecture,
 ## this allows us to ship PTX for only the latest supported level to
 ## enable PTX JIT for future architectures.
 ##
 ## Other packages just take in base cuda capability levels as listed
-## in the `cuda_levels` and `cuda11_levels` defines.
+## in the `cuda_levels` define.
 ##
 cuda_levels:
-  - 3.7;5.2;6.0;7.0;7.5     # [x86_64]
-  - 3.7;6.0;7.0;7.5         # [ppc64le]
+  - 3.7;5.2;6.0;7.0;7.5         # [x86_64 and cudatoolkit == '10.2']
+  - 3.7;5.2;6.0;7.0;7.5;8.0     # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
+  - 3.7;6.0;7.0;7.5             # [ppc64le and cudatoolkit == '10.2']
+  - 3.7;6.0;7.0;7.5;8.0         # [ppc64le and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
 cuda_levels_details:
   - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,compute_75        # [x86_64 and cudatoolkit == '10.2']
   - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,sm_80,compute_80  # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
   - sm_37,sm_60,sm_70,sm_75,compute_75                    # [ppc64le and cudatoolkit == '10.2']
   - sm_37,sm_60,sm_70,sm_75,sm_80,compute_80              # [ppc64le and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
-cuda11_levels:
-  - 8.0

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -331,10 +331,10 @@ vector_settings:
 ##
 # yamllint disable rule:line-length
 cuda_levels:
-  - 3.7;5.2;6.0;7.0;7.5         # [x86_64 and cudatoolkit == '10.2']
-  - 3.7;5.2;6.0;7.0;7.5;8.0     # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
-  - 3.7;6.0;7.0;7.5             # [ppc64le and cudatoolkit == '10.2']
-  - 3.7;6.0;7.0;7.5;8.0         # [ppc64le and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
+  - 3.7,5.2,6.0,7.0,7.5         # [x86_64 and cudatoolkit == '10.2']
+  - 3.7,5.2,6.0,7.0,7.5,8.0     # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
+  - 3.7,6.0,7.0,7.5             # [ppc64le and cudatoolkit == '10.2']
+  - 3.7,6.0,7.0,7.5,8.0         # [ppc64le and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
 cuda_levels_details:
   - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,compute_75        # [x86_64 and cudatoolkit == '10.2']
   - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,sm_80,compute_80  # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -329,6 +329,7 @@ vector_settings:
 ## Other packages just take in base cuda capability levels as listed
 ## in the `cuda_levels` define.
 ##
+# yamllint disable rule:line-length
 cuda_levels:
   - 3.7;5.2;6.0;7.0;7.5         # [x86_64 and cudatoolkit == '10.2']
   - 3.7;5.2;6.0;7.0;7.5;8.0     # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -320,7 +320,7 @@ vector_settings:
 ##     - compute_<cuda_arch> : include PTX
 ##     - sm_<cuda_arch> : do not include PTX
 ## These are passed in to the build via the
-## `cuda_level_details` and `cuda11_level_details` defines
+## `cuda_level_details` define
 ##
 ## Since CUBINs are compatible within the same major architecture,
 ## this allows us to ship PTX for only the latest supported level to
@@ -333,9 +333,9 @@ cuda_levels:
   - 3.7;5.2;6.0;7.0;7.5     # [x86_64]
   - 3.7;6.0;7.0;7.5         # [ppc64le]
 cuda_levels_details:
-  - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,compute_75  # [x86_64]
-  - sm_37,sm_60,sm_70,sm_75,compute_75              # [ppc64le]
+  - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,compute_75        # [x86_64 and cudatoolkit == '10.2']
+  - sm_37,sm_52,sm_60,sm_61,sm_70,sm_75,sm_80,compute_80  # [x86_64 and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
+  - sm_37,sm_60,sm_70,sm_75,compute_75                    # [ppc64le and cudatoolkit == '10.2']
+  - sm_37,sm_60,sm_70,sm_75,sm_80,compute_80              # [ppc64le and (cudatoolkit == '11.0' or cudatoolkit == '11.2')]
 cuda11_levels:
   - 8.0
-cuda11_levels_details:
-  - sm_80,compute_80


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Magma code expects cuda capabilities to be passed as `sm_` options, so adding `sm_75` and `sm_80` for CUDA 10.2 and CUDA 11 respectively. 

Also using either `compute_75` or `compute_80` depending on CUDA version to support PTX for the latest supported CUDA arch.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
