### PR TITLE
pins for transformers v4.9.2

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -228,7 +228,7 @@ regex:
 rust:
   - 1.54.0
 rust_compiler_version:
-- '1.46'
+  - '1.46'
 safeint:
   - 3.0
 scipy:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -55,7 +55,7 @@ cymem:
 cython:
   - 0.29
 cython_blis:
-  - 0.4.*
+  - 0.7.*
 dataclasses:
   - 0.7
 dm_tree:
@@ -207,8 +207,9 @@ protobuf:
   - 3.14.*
 psutil:
   - 5
+#forbid version 1.8.1 due to security vulnerability
 pydantic:
-  - 1.7.*
+  - 1.8.2
 pytest:
   - 5.*
 python:
@@ -242,7 +243,7 @@ six:
 smart_open:
   - 2.2.*
 spacy_legacy:
-  - 3.0.5
+  - 3.0.8
 srsly:
   - 2.*
 tabulate:
@@ -260,7 +261,7 @@ tensorflow_hub:
 termcolor:
   - 1.1.0
 thinc:
-  - 8.0.3
+  - 8.0.8
 tokenizers:
   - 0.10.3
 torchmetrics:
@@ -278,7 +279,7 @@ typing_extensions:
 unzip:
   - 6.0
 wasabi:
-  - 0.8.1
+  - 0.8.*
 werkzeug:
   - 1.*
 wheel:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -225,6 +225,8 @@ requests:
   - 2.*
 regex:
   - 2020.11.*
+rust:
+  - 1.56.0
 rust_compiler_version:
 - '1.46'
 safeint:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -224,7 +224,7 @@ requests:
   - 2.*
 regex:
   - 2020.11.*
-rust_nightly:
+rust:
   - 1.56.0
 safeint:
   - 3.0

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -225,7 +225,7 @@ requests:
 regex:
   - 2020.11.*
 rust_nightly:
-  - 1.53.0
+  - 1.56.0
 safeint:
   - 3.0
 scipy:
@@ -262,7 +262,7 @@ termcolor:
 thinc:
   - 8.0.3
 tokenizers:
-  - 0.10.1
+  - 0.10.3
 torchmetrics:
   - 0.3.*
 torchtext:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -226,7 +226,7 @@ requests:
 regex:
   - 2020.11.*
 rust:
-  - 1.56.0
+  - 1.54.0
 rust_compiler_version:
 - '1.46'
 safeint:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -238,7 +238,7 @@ setuptools:
   - 50.3.*   # [not s390x]
   - 51.*     # [s390x]
 setuptools_rust:
-  - 0.11.3
+  - 0.12.*
 six:
   - 1.15.0
 smart_open:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -224,8 +224,6 @@ requests:
   - 2.*
 regex:
   - 2020.11.*
-rust:
-  - 1.56.0
 rust_compiler_version:
 - '1.46'
 safeint:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -226,6 +226,8 @@ regex:
   - 2020.11.*
 rust:
   - 1.56.0
+rust_compiler_version:
+- '1.46'
 safeint:
   - 3.0
 scipy:

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -1,5 +1,6 @@
 packages:
   - feedstock : rust-nightly
   - feedstock : tokenizers
+  - feedstock : huggingface_hub
   - feedstock : sacremoses
   - feedstock : transformers

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -1,6 +1,8 @@
+imported_envs:
+  - arrow-env.yaml
 packages:
-  - feedstock : rust-nightly
   - feedstock : tokenizers
   - feedstock : huggingface_hub
   - feedstock : sacremoses
+  - feedstock : sentencepiece
   - feedstock : transformers


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Add pins for transformers v4.9.2. 

`Sentencepiece` is an optional dependency of transformers, but some tests require `sentencepiece`. Adding `sentencepiece` to the `transformers-env.yaml` makes it available in the generated environment yaml which is later used for creating the test environment. 

Some tests also require `pyarrow`, so building it too, as part of the `transformers-env.yaml`. 

`pyarrow` available on defaults could not be used because the following confict:
**pyarrow on defaults**:-> `arrow-cpp ->    libprotobuf >=3.11.2,<3.12.0a0`
**sentencepiece on open-ce**:-> `  protobuf 3.14.*`


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
