### PR TITLE
remove arrow-env as this is no longer needed

### DIFF
--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -1,5 +1,3 @@
-imported_envs:
-  - arrow-env.yaml
 packages:
   - feedstock : tokenizers
   - feedstock : huggingface_hub


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

This PR removes `arrow-env` from `transformers-env.yaml`. arrow-env was added earlier because `pyarrow` was required by datasets package which was installed using pip in the `open-ce-tests.yaml`.

However, the entire transformers test suite is taking more than 3 hours, so have raised a PR - https://github.com/open-ce/transformers-feedstock/pull/24 to execute only a small subset of the test suite as part of the `open-ce-tests.yaml`. So datasets and hence arrow is not required for test execution. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
