### PR TITLE
Update werkzeug to 2.0.1 to fix a CVE

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -250,7 +250,7 @@ unzip:
 wasabi:
   - 0.6.0
 werkzeug:
-  - 1.*
+  - 2.*
 wheel:
   - 0.35*
 wrapt:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Updates werkzeug to 2.0.1 to fix a CVE reported for 1.* which is fixed in versions >=2.0.0. Anaconda has 2.0.1 as the latest version of werkzeug available.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
