### PR TITLE
Fixed pyarrow build on s390x

### DIFF
--- a/envs/arrow-env.yaml
+++ b/envs/arrow-env.yaml
@@ -6,6 +6,8 @@ packages:
       - feedstock-patches/rapidjson/s390x-fix1.patch
   - feedstock : https://github.com/AnacondaRecipes/orc-feedstock
     git_tag: 47b595ae87b7bd10b16e08aef41e1b9e9d257848
+    patches:
+      - feedstock-patches/orc/0001-Pin-protobuf-to-3.14.patch
   - feedstock : https://github.com/conda-forge/libutf8proc-feedstock
     git_tag: d2a2366dc3c02405b1b54b991758b5bb57b75e6d
   - feedstock : https://github.com/AnacondaRecipes/re2-feedstock

--- a/envs/feedstock-patches/orc/0001-Pin-protobuf-to-3.14.patch
+++ b/envs/feedstock-patches/orc/0001-Pin-protobuf-to-3.14.patch
@@ -1,0 +1,31 @@
+From 8dbdb28766946ddd90ba4490984a797759b25666 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Mon, 3 Jan 2022 13:59:25 +0000
+Subject: [PATCH] Pin protobuf to 3.14
+
+---
+ recipe/meta.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index f4dd818..1b649f9 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -28,12 +28,12 @@ requirements:
+     - patch  # [not win]
+     - ninja       # [unix]
+     # `protoc` is also used for building
+-    - libprotobuf
++    - libprotobuf {{ protobuf }}
+     - cmake
+   host:
+     - zlib
+     - snappy
+-    - libprotobuf
++    - libprotobuf {{ protobuf }}
+     - lz4-c
+     - zstd
+ 
+-- 
+2.23.0
+


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes pyarrow build on s390x. The failure was due to orc which was being built using the latest protobuf  which is 3.19.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
