### PR TITLE
add separate p10 env file

### DIFF
--- a/envs/common-feedstocks-env.yaml
+++ b/envs/common-feedstocks-env.yaml
@@ -1,0 +1,7 @@
+packages:
+{% if not s390x %}
+  - feedstock : openblas
+  - feedstock : opencv
+{% endif %}
+
+git_tag_for_env: open-ce-v1.5.3

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -1,4 +1,5 @@
 imported_envs:
+  - common-feedstocks-env.yaml
   - onnx-env.yaml
   - pytorch-env.yaml
   - pytorch-extras-env.yaml
@@ -12,11 +13,5 @@ imported_envs:
   - arrow-env.yaml
   - uwsgi-env.yaml
   - mamba-env.yaml
-
-packages:
-{% if not s390x %}
-  - feedstock : openblas
-  - feedstock : opencv
-{% endif %}
 
 git_tag_for_env: open-ce-v1.5.3

--- a/envs/opence-p10-env.yaml
+++ b/envs/opence-p10-env.yaml
@@ -4,14 +4,9 @@ imported_envs:
   - pytorch-extras-env.yaml
   - tensorflow-env.yaml
   - xgboost-env.yaml
-  - dali-env.yaml
-  - spacy-env.yaml
-  - transformers-env.yaml
-  - horovod-env.yaml
   - lightgbm-env.yaml
   - arrow-env.yaml
   - uwsgi-env.yaml
-  - mamba-env.yaml
 
 packages:
 {% if not s390x %}

--- a/envs/opence-p10-env.yaml
+++ b/envs/opence-p10-env.yaml
@@ -1,4 +1,5 @@
 imported_envs:
+  - common-feedstocks-env.yaml
   - onnx-env.yaml
   - pytorch-env.yaml
   - pytorch-extras-env.yaml
@@ -7,11 +8,5 @@ imported_envs:
   - lightgbm-env.yaml
   - arrow-env.yaml
   - uwsgi-env.yaml
-
-packages:
-{% if not s390x %}
-  - feedstock : openblas
-  - feedstock : opencv
-{% endif %}
 
 git_tag_for_env: open-ce-v1.5.3


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The `ppc_arch` selector is not working correctly in the `opence-env.yaml`. So all envs listed in `opence-env.yaml` that have the selector mentioned are getting ignored for non-p10 binaries. 

This PR adds a separate `opence-p10-env.yaml` to avoid usage of `ppc_arch` selector in the top level env file. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
