### PR TITLE
Enable flatbuffers for s390x

### DIFF
--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -1,5 +1,6 @@
 imported_envs:
   - bazel-env.yaml
+  - tensorflow-s390x-extra-deps-env.yaml
 
 packages:
 {% if not s390x %}

--- a/envs/tensorflow-s390x-extra-deps-env.yaml
+++ b/envs/tensorflow-s390x-extra-deps-env.yaml
@@ -1,0 +1,5 @@
+packages:
+{% if s390x %}
+  - feedstock : https://github.com/AnacondaRecipes/flatbuffers-feedstock.git
+    git_tag: c7bd7770705d34151e80cae10b7b4a4cc960094f
+{% endif %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
- `flatbuffers` is dependency for `Tensorflow` and  conda package is not available for s390x.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
