### PR TITLE
build uvicorn locally to fix gen-license failure

### DIFF
--- a/envs/feedstock-patches/unicorn/0001-remove-unicode-char-from-summary.patch
+++ b/envs/feedstock-patches/unicorn/0001-remove-unicode-char-from-summary.patch
@@ -1,0 +1,25 @@
+From 89be1131258c99aed871a1ce3690a1f0cc84ce9c Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Mon, 18 Apr 2022 06:16:08 +0000
+Subject: [PATCH] remove unicode char from summary
+
+---
+ recipe/meta.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index c722092..66b7aa5 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -40,7 +40,7 @@ about:
+   license: BSD-3-Clause
+   license_family: BSD
+   license_file: LICENSE.md
+-  summary: The lightning-fast ASGI server. 🦄
++  summary: The lightning-fast ASGI server.
+   description: |
+     Uvicorn is a lightning-fast ASGI server implementation,
+     using [uvloop](https://github.com/MagicStack/uvloop) and
+-- 
+2.32.0
+

--- a/envs/ray-env.yaml
+++ b/envs/ray-env.yaml
@@ -7,6 +7,10 @@ imported_envs:
 
 packages:
 {% if build_type == 'cpu' %}
+  - feedstock : https://github.com/AnacondaRecipes/uvicorn-feedstock.git
+    git_tag: 312dca71c6d5a752ad6a2ab7c0a65a55b71a3e81
+    patches:
+      -  feedstock-patches/unicorn/0001-remove-unicode-char-from-summary.patch
   - feedstock : https://github.com/conda-forge/starlette-feedstock
     git_tag: 1affc7a9146e771582508b1b7311c4f635579211
   - feedstock : https://github.com/conda-forge/python-multipart-feedstock


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Build `uvicorn `locally with a patch to fix the below failure observed during gen-license:
```
yaml.scanner.ScannerError: while parsing a quoted scalar
  in "/opt/conda/pkgs/uvicorn-0.16.0-py39h06a4308_0/info/about.json", line 92, column 14
found invalid Unicode character escape code
  in "/opt/conda/pkgs/uvicorn-0.16.0-py39h06a4308_0/info/about.json", line 92, column 49
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
