### PR TITLE
Update starlette version to 0.18

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -275,7 +275,7 @@ spdlog:
 srsly:
   - 2.*
 starlette:
-  - 0.17.*
+  - 0.18.*
 tabulate:
   - 0.8.*
 tensorboard:

--- a/envs/ray-env.yaml
+++ b/envs/ray-env.yaml
@@ -12,7 +12,7 @@ packages:
     patches:
       -  feedstock-patches/unicorn/0001-remove-unicode-char-from-summary.patch
   - feedstock : https://github.com/conda-forge/starlette-feedstock
-    git_tag: 1affc7a9146e771582508b1b7311c4f635579211
+    git_tag: 3dd6ec5df98797b241160bf354d88bb1c30e2258
   - feedstock : https://github.com/conda-forge/python-multipart-feedstock
   - feedstock : https://github.com/conda-forge/gym-feedstock
     git_tag: 2a7ffecb73b770d6889ec06e133bd3cfe8c02041


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

fastapi recipe has been failing with an error "Unsatisfiable dependencies for platform linux-ppc64le: {'starlette=0.18.0'}". 
Recently conda-forge updated pin of starlette in fastapi recipe from 0.17 to 0.18. So, Open-CE should also build starlette 0.18 hereon.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
