### PR TITLE
add patch to fix spdlog build on baremetal

### DIFF
--- a/envs/feedstock-patches/spdlog/0001-disable-systemd-tests-to-fix-baremetal-build.patch
+++ b/envs/feedstock-patches/spdlog/0001-disable-systemd-tests-to-fix-baremetal-build.patch
@@ -1,0 +1,45 @@
+From 7f588cf44530ef7c36aa08f40675b1256388a26a Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Wed, 11 May 2022 03:52:02 -0400
+Subject: [PATCH] disable systemd tests
+
+---
+ recipe/0001-disable-systemd-tests.patch | Bin 0 -> 659 bytes
+ recipe/meta.yaml                        |   2 ++
+ 2 files changed, 2 insertions(+)
+ create mode 100644 recipe/0001-disable-systemd-tests.patch
+
+diff --git a/recipe/0001-disable-systemd-tests.patch b/recipe/0001-disable-systemd-tests.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..20496cf0034dc43b46def13afc98c8f302ca6191
+GIT binary patch
+literal 659
+zcmZ`$%Wm5+5WMp%_9(*^O-Ym$2}R*Tj@v_A8<mY7ib9~smBd;vSTv9T`S?;!(nHV?
+zJnYUahr{9a(zg(oet=x?l`NDDR)WWoj|C4yFP23V3s$OdB}xXnzJm-0@FHL=xoz+n
+z^T^i9B(OmoM57_C`|CxFTEHh|AzAyuT6a_zEtP%ynQVl?1b(7gfak$ZJXsOn2None
+zPW%X5#u+2owfKY5B=GC-<(Pi^4N8xqXb{Gy(O|2<;AlodT-PNp^)lUwGd^ewQ}bxx
+z8A7n^#CuR`dsNn<tEPKHP}rc+eK$Jpj1Z;E(#}@efLPvy--{Lhg^BJIK0;I?k75rg
+zErTGG0q5W`w&Hwp_kkjr&*$)g>Us_C-NJ@5zgw)pcGy{m&Wr#7-O1*v(4llGTl?PS
+z)#zrVw|W|IOY12ggglE1ox{0G`>xd0jJQ_eUz>0Dr|%mJf?dP8%4Lo6oVUHYHaI$O
+z88^CkE$!%=37hAL#>ozwhyB<5biB`wS)T1rKhpb*OnSHP$fv~f8k+$xR1U*?rs=Cn
+Qch!xuArYVY5oLt@1zGdSuK)l5
+
+literal 0
+HcmV?d00001
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 3c3e2df..2963752 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -9,6 +9,8 @@ package:
+ source:
+   url: https://github.com/gabime/{{ name|lower }}/archive/v{{ version }}.tar.gz
+   sha256: {{ sha256 }}
++  patches:
++    - 0001-disable-systemd-tests.patch
+ 
+ build:
+   number: 1
+-- 
+2.27.0
+

--- a/envs/feedstock-patches/spdlog/0001-disable-systemd-tests-to-fix-baremetal-build.patch
+++ b/envs/feedstock-patches/spdlog/0001-disable-systemd-tests-to-fix-baremetal-build.patch
@@ -1,32 +1,48 @@
-From 7f588cf44530ef7c36aa08f40675b1256388a26a Mon Sep 17 00:00:00 2001
+From f7efa74075152ed54aa90dfa9fa135e161827da9 Mon Sep 17 00:00:00 2001
 From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Wed, 11 May 2022 03:52:02 -0400
-Subject: [PATCH] disable systemd tests
+Date: Wed, 11 May 2022 08:08:39 -0400
+Subject: [PATCH] disable tests that link with systemd
 
 ---
- recipe/0001-disable-systemd-tests.patch | Bin 0 -> 659 bytes
- recipe/meta.yaml                        |   2 ++
- 2 files changed, 2 insertions(+)
+ recipe/0001-disable-systemd-tests.patch | 28 +++++++++++++++++++++++++
+ recipe/meta.yaml                        |  2 ++
+ 2 files changed, 30 insertions(+)
  create mode 100644 recipe/0001-disable-systemd-tests.patch
 
 diff --git a/recipe/0001-disable-systemd-tests.patch b/recipe/0001-disable-systemd-tests.patch
 new file mode 100644
-index 0000000000000000000000000000000000000000..20496cf0034dc43b46def13afc98c8f302ca6191
-GIT binary patch
-literal 659
-zcmZ`$%Wm5+5WMp%_9(*^O-Ym$2}R*Tj@v_A8<mY7ib9~smBd;vSTv9T`S?;!(nHV?
-zJnYUahr{9a(zg(oet=x?l`NDDR)WWoj|C4yFP23V3s$OdB}xXnzJm-0@FHL=xoz+n
-z^T^i9B(OmoM57_C`|CxFTEHh|AzAyuT6a_zEtP%ynQVl?1b(7gfak$ZJXsOn2None
-zPW%X5#u+2owfKY5B=GC-<(Pi^4N8xqXb{Gy(O|2<;AlodT-PNp^)lUwGd^ewQ}bxx
-z8A7n^#CuR`dsNn<tEPKHP}rc+eK$Jpj1Z;E(#}@efLPvy--{Lhg^BJIK0;I?k75rg
-zErTGG0q5W`w&Hwp_kkjr&*$)g>Us_C-NJ@5zgw)pcGy{m&Wr#7-O1*v(4llGTl?PS
-z)#zrVw|W|IOY12ggglE1ox{0G`>xd0jJQ_eUz>0Dr|%mJf?dP8%4Lo6oVUHYHaI$O
-z88^CkE$!%=37hAL#>ozwhyB<5biB`wS)T1rKhpb*OnSHP$fv~f8k+$xR1U*?rs=Cn
-Qch!xuArYVY5oLt@1zGdSuK)l5
-
-literal 0
-HcmV?d00001
-
+index 0000000..20496cf
+--- /dev/null
++++ b/recipe/0001-disable-systemd-tests.patch
+@@ -0,0 +1,28 @@
++From 9f23e4a46cbdc36a4972eb45519cb79a0fd56af0 Mon Sep 17 00:00:00 2001
++From: Deepali Chourasia <deepch23@in.ibm.com>
++Date: Wed, 11 May 2022 03:49:27 -0400
++Subject: [PATCH] disable systemd tests
++
++---
++ tests/CMakeLists.txt | 5 -----
++ 1 file changed, 5 deletions(-)
++
++diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
++index 7fe4791e..f335c344 100644
++--- a/tests/CMakeLists.txt
+++++ b/tests/CMakeLists.txt
++@@ -8,11 +8,6 @@ endif()
++ 
++ include(../cmake/utils.cmake)
++ 
++-find_package(PkgConfig)
++-if(PkgConfig_FOUND)
++-    pkg_check_modules(systemd libsystemd)
++-endif()
++-
++ set(SPDLOG_UTESTS_SOURCES
++     test_file_helper.cpp
++     test_file_logging.cpp
++-- 
++2.27.0
++
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
 index 3c3e2df..2963752 100644
 --- a/recipe/meta.yaml
@@ -41,5 +57,5 @@ index 3c3e2df..2963752 100644
  build:
    number: 1
 -- 
-2.27.0
+2.23.0
 

--- a/envs/mamba-env.yaml
+++ b/envs/mamba-env.yaml
@@ -19,6 +19,8 @@ packages:
     git_tag : a4377e7bb252838fe3b2595a976a4f1b9a60341b
   - feedstock : https://github.com/conda-forge/spdlog-feedstock.git
     git_tag: 6f6a8b720f06142b20e03fe7236a79ea5b594728
+    patches:
+          - feedstock-patches/spdlog/0001-disable-systemd-tests-to-fix-baremetal-build.patch
   - feedstock : https://github.com/conda-forge/termcolor-cpp-feedstock.git
     git_tag : f35835967df63a49285fb70ea08edd704ab0aa79	
   - feedstock : https://github.com/conda-forge/yaml-cpp-feedstock.git


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Add a patch to disable compilation of spdlog tests that link with libsystemd. These tests anyway do not build on containers because containers do not have libsystemd. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
