### PR TITLE
rust1.62 dependency added  for tokenizer

### DIFF
--- a/envs/feedstock-patches/transformer/0001-fix-to-build-with-rust.patch
+++ b/envs/feedstock-patches/transformer/0001-fix-to-build-with-rust.patch
@@ -1,16 +1,17 @@
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 9e65b2c..66af849 100644
+index 9e65b2c..cd2ff24 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
-@@ -26,7 +26,6 @@ build:
+@@ -26,8 +26,6 @@ build:
  requirements:
    build:
      - posix  # [win]
 -  host:
- 
+-
  outputs:
    - name: rust-std-{{ rust_arch }}
-@@ -41,11 +40,6 @@ outputs:
+     build:
+@@ -41,11 +39,6 @@ outputs:
          - /lib64/libc.so.6  # [linux]
          - /lib64/ld-linux-x86-64.so.2  # [linux]
        merge_build_host: false
@@ -22,22 +23,20 @@ index 9e65b2c..66af849 100644
      script: install-rust-std.sh  # [unix]
      script: install-rust-std.bat  # [win]
      test:
-@@ -70,12 +64,10 @@ outputs:
+@@ -70,12 +63,7 @@ outputs:
          # Added as run deps: libgcc-ng (via compiler strong run_exports), zlib
          # - /lib64/libgcc_s.so.1  # [linux]
          # - /lib64/libz.so.1  # [linux]
 -    run_exports:
 -      strong_constrains:
-+    run_exports: # [osx and x86_64]
-+      strong_constrains:  # [osx and x86_64]
-         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
      requirements:
 -      build:
 -        - posix  # [win]
        host:
          - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
          - {{ compiler('c') }}  # [linux] -- rustc needs a toolchain to link executables
-@@ -85,8 +77,6 @@ outputs:
+@@ -85,8 +73,6 @@ outputs:
          - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
          - gcc_impl_{{ target_platform }}  # [linux]
      test:

--- a/envs/feedstock-patches/transformer/0001-fix-to-build-with-rust.patch
+++ b/envs/feedstock-patches/transformer/0001-fix-to-build-with-rust.patch
@@ -1,0 +1,48 @@
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 9e65b2c..66af849 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -26,7 +26,6 @@ build:
+ requirements:
+   build:
+     - posix  # [win]
+-  host:
+ 
+ outputs:
+   - name: rust-std-{{ rust_arch }}
+@@ -41,11 +40,6 @@ outputs:
+         - /lib64/libc.so.6  # [linux]
+         - /lib64/ld-linux-x86-64.so.2  # [linux]
+       merge_build_host: false
+-    requirements:
+-      build:
+-        - posix  # [win]
+-      host:
+-      run:
+     script: install-rust-std.sh  # [unix]
+     script: install-rust-std.bat  # [win]
+     test:
+@@ -70,12 +64,10 @@ outputs:
+         # Added as run deps: libgcc-ng (via compiler strong run_exports), zlib
+         # - /lib64/libgcc_s.so.1  # [linux]
+         # - /lib64/libz.so.1  # [linux]
+-    run_exports:
+-      strong_constrains:
++    run_exports: # [osx and x86_64]
++      strong_constrains:  # [osx and x86_64]
+         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+     requirements:
+-      build:
+-        - posix  # [win]
+       host:
+         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
+         - {{ compiler('c') }}  # [linux] -- rustc needs a toolchain to link executables
+@@ -85,8 +77,6 @@ outputs:
+         - {{ pin_subpackage("rust-std-" ~ rust_arch, exact=True) }}
+         - gcc_impl_{{ target_platform }}  # [linux]
+     test:
+-      requires:
+-        - posix  # [win]
+       commands:
+         - rustc --help
+         - rustdoc --help

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -2,6 +2,10 @@ builder_version: ">=10.0.1"
 
 packages:
 {% if not s390x %}
+  - feedstock : https://github.com/conda-forge/rust-feedstock.git
+    git_tag : 429557ee73ad0f98221df7260733506ac03d30ae
+    patches :
+            - feedstock-patches/transformer/0001-fix-to-build-with-rust.patch
   - feedstock : tokenizers
   - feedstock : huggingface_hub
   - feedstock : sacremoses


### PR DESCRIPTION
## Checklist before submitting

- [X] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Newer version of rust (1.62) required for build of tokenizer feedstock which is yet not available in conda. hence added  remote feedstock in transformer env file with required patch for rust.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
