### PR TITLE
changes to enable use of system GCC for p10 build again

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -321,7 +321,7 @@ typing_extensions:
 unzip:
   - 6.0
 wasabi:
-  - 0.8.*
+  - 0.9.*
 werkzeug:
   - 2.*
 wheel:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -195,7 +195,7 @@ numactl:
 numpy:
   - 1.22.*
 onnx:
-  - 1.11.*
+  - 1.12.*
 onnxconverter_common:
   - 1.9.*
 onnx_graphsurgeon:

--- a/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
+++ b/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
@@ -1,0 +1,155 @@
+From ec25b696c12dce5dbd0e93679c791b3d1577dc6b Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Thu, 14 Jul 2022 09:51:26 +0000
+Subject: [PATCH] Fixed clang for P10
+
+---
+ recipe/build.sh  | 13 +++++++++++++
+ recipe/meta.yaml | 27 +++++++++++++++------------
+ 2 files changed, 28 insertions(+), 12 deletions(-)
+
+diff --git a/recipe/build.sh b/recipe/build.sh
+index 1ebb0d7..9eb30ed 100644
+--- a/recipe/build.sh
++++ b/recipe/build.sh
+@@ -4,6 +4,19 @@ IFS='.' read -r -a PKG_VER_ARRAY <<< "${PKG_VERSION}"
+ 
+ sed -i.bak "s/libLTO.dylib/libLTO.${PKG_VER_ARRAY[0]}.dylib/g" lib/Driver/ToolChains/Darwin.cpp
+ 
++if [[ $ppc_arch == "p10" ]]
++then
++    if [[ -z "${GCC_11_HOME}" ]];
++    then
++        echo "Please set GCC_11_HOME to the install path of gcc-toolset-11"
++        exit 1
++    else
++        AR=$GCC_11_HOME/bin/ar
++        rm ${PREFIX}/lib/libstdc++.so*
++        rm ${BUILD_PREFIX}/lib/libstdc++.so*
++    fi
++fi
++
+ if [[ "$variant" == "hcc" ]]; then
+   CMAKE_ARGS="$CMAKE_ARGS -DKALMAR_BACKEND=HCC_BACKEND_AMDGPU -DHCC_VERSION_STRING=2.7-19365-24e69cd8-24e69cd8-24e69cd8"
+   CMAKE_ARGS="$CMAKE_ARGS -DHCC_VERSION_MAJOR=2 -DHCC_VERSION_MINOR=7 -DHCC_VERSION_PATCH=19365"
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 4bc43a4..658aaec 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -35,10 +35,12 @@ source:
+ build:
+   number: {{ build_number }}
+   skip: true  # [(win and vc<14) or variant=="hcc"]
++  script_env:                  # [ppc_arch == "p10"]
++    - GCC_11_HOME              # [ppc_arch == "p10"]
+ 
+ requirements:
+   build:
+-    - {{ compiler('cxx') }}
++    - {{ compiler('cxx') }}      # [ ppc_arch != "p10"]
+     - cmake >=3.4.3
+     # Needed to unpack the source tarball
+     - m2w64-xz  # [win]
+@@ -61,7 +63,7 @@ requirements:
+ 
+ test:
+   requires:
+-    - {{ compiler('cxx') }}
++    - {{ compiler('cxx') }}     # [ ppc_arch != "p10"]
+     - cmake >=3.4.3
+   files:
+     - mytest.c
+@@ -88,7 +90,7 @@ outputs:
+       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}     # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+@@ -134,7 +136,7 @@ outputs:
+       skip: true  # [win]
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}     # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+@@ -171,7 +173,7 @@ outputs:
+       {% endif %}
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}   # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+@@ -208,7 +210,7 @@ outputs:
+         - libclang {{ minor_aware_ext }}.*
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}    # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja                      # [win]
+         - make                       # [unix]
+@@ -248,7 +250,7 @@ outputs:
+       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}      # [ ppc_arch != "p10"]
+         - libcxx                             # [osx]
+         - cmake >=3.4.3
+         - ninja                              # [win]
+@@ -340,7 +342,7 @@ outputs:
+         - {{ pin_subpackage("clang", exact=True) }}
+     test:
+       requires:
+-        - {{ compiler("cxx") }}
++        - {{ compiler("cxx") }}             # [ ppc_arch != "p10"]
+         - libgcc-ng {{ libgcc }}            #[cudatoolkit == "11.2"]
+         - libstdcxx-ng {{ libstdcxx }}      #[cudatoolkit == "11.2"]
+         - libgfortran-ng {{ libgfortran }}  #[cudatoolkit == "11.2"]
+@@ -348,7 +350,8 @@ outputs:
+         - mytest.cxx
+       commands:
+         - clang++ --version
+-        - clang++ -v -c mytest.cxx
++        - clang++ --gcc-toolchain=$GCC_11_HOME -v -c mytest.cxx  # [ ppc_arch == "p10"]
++        - clang++ -v -c mytest.cxx  # [ ppc_arch != "p10"]
+ 
+   - name: clang-format-{{ major_version }}
+     script: install_clang_format.sh  # [unix]
+@@ -363,7 +366,7 @@ outputs:
+       build:
+         # "compiling .pyc files" fails without this
+         - python >3
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}     # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+@@ -406,7 +409,7 @@ outputs:
+       build:
+         # "compiling .pyc files" fails without this
+         - python >3
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}       # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+@@ -448,7 +451,7 @@ outputs:
+       build:
+         # "compiling .pyc files" fails without this
+         - python >3
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}      # [ ppc_arch != "p10"]
+         - cmake >=3.4.3
+         - ninja  # [win]
+         - make   # [unix]
+-- 
+2.34.1
+

--- a/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
+++ b/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
@@ -1,15 +1,15 @@
-From 101c912ef183f4112f7aca98b3f30e038482fe4f Mon Sep 17 00:00:00 2001
+From 120d38531df74f6b3fb137c184616e94d90c2313 Mon Sep 17 00:00:00 2001
 From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Thu, 14 Jul 2022 15:56:48 +0000
-Subject: [PATCH] Fixed build for P10
+Date: Mon, 18 Jul 2022 08:36:11 +0000
+Subject: [PATCH] Fix clang for P10
 
 ---
- recipe/build.sh  | 11 +++++++++++
+ recipe/build.sh  | 12 ++++++++++++
  recipe/meta.yaml | 27 +++++++++++++++------------
- 2 files changed, 26 insertions(+), 12 deletions(-)
+ 2 files changed, 27 insertions(+), 12 deletions(-)
 
 diff --git a/recipe/build.sh b/recipe/build.sh
-index 1ebb0d7..3604aea 100644
+index 1ebb0d7..35a9a27 100644
 --- a/recipe/build.sh
 +++ b/recipe/build.sh
 @@ -4,6 +4,17 @@ IFS='.' read -r -a PKG_VER_ARRAY <<< "${PKG_VERSION}"
@@ -30,6 +30,14 @@ index 1ebb0d7..3604aea 100644
  if [[ "$variant" == "hcc" ]]; then
    CMAKE_ARGS="$CMAKE_ARGS -DKALMAR_BACKEND=HCC_BACKEND_AMDGPU -DHCC_VERSION_STRING=2.7-19365-24e69cd8-24e69cd8-24e69cd8"
    CMAKE_ARGS="$CMAKE_ARGS -DHCC_VERSION_MAJOR=2 -DHCC_VERSION_MINOR=7 -DHCC_VERSION_PATCH=19365"
+@@ -26,6 +37,7 @@ cd build
+ 
+ export CXXFLAGS="${CXXFLAGS} -fplt"
+ export CFLAGS="${CFLAGS} -fplt"
++export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${PREFIX}/lib
+ 
+ cmake \
+   -DCMAKE_INSTALL_PREFIX=$PREFIX \
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
 index 4bc43a4..658aaec 100644
 --- a/recipe/meta.yaml

--- a/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
+++ b/envs/feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
@@ -1,18 +1,18 @@
-From ec25b696c12dce5dbd0e93679c791b3d1577dc6b Mon Sep 17 00:00:00 2001
+From 101c912ef183f4112f7aca98b3f30e038482fe4f Mon Sep 17 00:00:00 2001
 From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Thu, 14 Jul 2022 09:51:26 +0000
-Subject: [PATCH] Fixed clang for P10
+Date: Thu, 14 Jul 2022 15:56:48 +0000
+Subject: [PATCH] Fixed build for P10
 
 ---
- recipe/build.sh  | 13 +++++++++++++
+ recipe/build.sh  | 11 +++++++++++
  recipe/meta.yaml | 27 +++++++++++++++------------
- 2 files changed, 28 insertions(+), 12 deletions(-)
+ 2 files changed, 26 insertions(+), 12 deletions(-)
 
 diff --git a/recipe/build.sh b/recipe/build.sh
-index 1ebb0d7..9eb30ed 100644
+index 1ebb0d7..3604aea 100644
 --- a/recipe/build.sh
 +++ b/recipe/build.sh
-@@ -4,6 +4,19 @@ IFS='.' read -r -a PKG_VER_ARRAY <<< "${PKG_VERSION}"
+@@ -4,6 +4,17 @@ IFS='.' read -r -a PKG_VER_ARRAY <<< "${PKG_VERSION}"
  
  sed -i.bak "s/libLTO.dylib/libLTO.${PKG_VER_ARRAY[0]}.dylib/g" lib/Driver/ToolChains/Darwin.cpp
  
@@ -24,8 +24,6 @@ index 1ebb0d7..9eb30ed 100644
 +        exit 1
 +    else
 +        AR=$GCC_11_HOME/bin/ar
-+        rm ${PREFIX}/lib/libstdc++.so*
-+        rm ${BUILD_PREFIX}/lib/libstdc++.so*
 +    fi
 +fi
 +

--- a/envs/feedstock-patches/h5py/0001-P10-changes.patch
+++ b/envs/feedstock-patches/h5py/0001-P10-changes.patch
@@ -1,0 +1,25 @@
+From a073c04fb7a6fad54ac99f2cd37c25a1d0ef1bb6 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Wed, 20 Jul 2022 05:08:49 +0000
+Subject: [PATCH] P10 changes
+
+---
+ recipe/meta.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 713a39f..809496a 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -23,7 +23,7 @@ build:
+ 
+ requirements:
+   build:
+-    - {{ compiler("c") }}
++    - {{ compiler("c") }}       #[ppc_arch != 'p10']
+     - m2-patch  # [win]
+     - patch     # [not win]
+   host:
+-- 
+2.34.1
+

--- a/envs/feedstock-patches/llvm/0001-Fix-build-for-P10.patch
+++ b/envs/feedstock-patches/llvm/0001-Fix-build-for-P10.patch
@@ -1,0 +1,81 @@
+From 0113d6d1fa715daea2011403731c150fa9a28a54 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Thu, 14 Jul 2022 12:01:07 +0000
+Subject: [PATCH] Fix build for P10
+
+---
+ recipe/build.sh  | 12 ++++++++++++
+ recipe/meta.yaml | 10 ++++++----
+ 2 files changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/recipe/build.sh b/recipe/build.sh
+index 66651ec..1311f4e 100644
+--- a/recipe/build.sh
++++ b/recipe/build.sh
+@@ -4,6 +4,18 @@ set -x
+ sed -i.bak "s/NOT APPLE AND ARG_SONAME/ARG_SONAME/g" cmake/modules/AddLLVM.cmake
+ sed -i.bak "s/NOT APPLE AND NOT ARG_SONAME/NOT ARG_SONAME/g" cmake/modules/AddLLVM.cmake
+ 
++if [[ $ppc_arch == "p10" ]]
++then
++    if [[ -z "${GCC_11_HOME}" ]];
++    then
++        echo "Please set GCC_11_HOME to the install path of gcc-toolset-11"
++        exit 1
++    else
++        AR=$GCC_11_HOME/bin/ar
++        rm ${BUILD_PREFIX}/lib/libstdc++.so*
++    fi
++fi
++
+ mkdir build
+ cd build
+ 
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 0c273a9..b42e7fc 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -19,10 +19,12 @@ source:
+ build:
+   number: 0
+   merge_build_host: false
++  script_env:          #[ppc_arch == 'p10']
++    - GCC_11_HOME      #[ppc_arch == 'p10']
+ 
+ requirements:
+   build:
+-    - {{ compiler('cxx') }}
++    - {{ compiler('cxx') }}   # [ ppc_arch != "p10"]
+     - cmake
+     - ninja     # [win]
+     - python    >=3
+@@ -49,7 +51,7 @@ outputs:
+       activate_in_script: true
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}    # [ ppc_arch != "p10"]
+         - make      # [not win]
+         - cmake
+         - ninja     # [win]
+@@ -88,7 +90,7 @@ outputs:
+         - {{ pin_subpackage("libllvm" + major_ver, max_pin="x.x") }}  # [not win]
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}   # [ ppc_arch != "p10"]
+         - make                     # [not win]
+         - cmake                    # [not win]
+         - python    >=3            # [not win]
+@@ -147,7 +149,7 @@ outputs:
+       activate_in_script: true
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}    # [ ppc_arch != "p10"]
+         - make      # [not win]
+         - cmake
+         - ninja     # [win]
+-- 
+2.34.1
+

--- a/envs/feedstock-patches/openmp/0003-P10-changes.patch
+++ b/envs/feedstock-patches/openmp/0003-P10-changes.patch
@@ -35,7 +35,7 @@ index 0d309e3..af5395a 100644
          - test -f $PREFIX/include/omp.h                   # [unix]
 -        - $PREFIX/bin/clang -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win]
 +        - $PREFIX/bin/clang --gcc-toolchain=$GCC_11_HOME -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win and ppc_arch == 'p10']
-+        - $PREFIX/bin/clang --gcc-toolchain=$GCC_11_HOME -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win and ppc_arch != 'p10']
++        - $PREFIX/bin/clang -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win and ppc_arch != 'p10']
          - '%LIBRARY_BIN%\clang -v -fopenmp -I%LIBRARY_INC% -L%LIBRARY_LIB% omp_hello.c -o omp_hello.exe'   # [win]
          - ./omp_hello            # [unix]
          - '%cd%\omp_hello.exe'   # [win]

--- a/envs/feedstock-patches/openmp/0003-P10-changes.patch
+++ b/envs/feedstock-patches/openmp/0003-P10-changes.patch
@@ -1,0 +1,44 @@
+From da5201e5076d38b467a7f7c69e6538dd0e337cd3 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Mon, 18 Jul 2022 13:22:20 +0000
+Subject: [PATCH] P10 changes
+
+---
+ recipe/meta.yaml | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 0d309e3..af5395a 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -29,7 +29,7 @@ outputs:
+           - {{ pin_subpackage("llvm-openmp", max_pin=None) }}
+     requirements:
+       build:
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}      #[ppc_arch != 'p10']
+         - clang  # [win]
+         - cmake
+         - make   # [unix]
+@@ -45,7 +45,7 @@ outputs:
+     test:
+       requires:
+         - clangxx
+-        - {{ compiler('cxx') }}
++        - {{ compiler('cxx') }}      #[ppc_arch != 'p10']
+       commands:
+         - if not exist %LIBRARY_BIN%\\libomp.dll exit 1   # [win]
+         - test -f $PREFIX/lib/libomp.so                   # [linux]
+@@ -53,7 +53,8 @@ outputs:
+         - if not exist %LIBRARY_LIB%\\libomp.lib exit 1   # [win]
+         - if not exist %LIBRARY_INC%\\omp.h exit 1        # [win]
+         - test -f $PREFIX/include/omp.h                   # [unix]
+-        - $PREFIX/bin/clang -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win]
++        - $PREFIX/bin/clang --gcc-toolchain=$GCC_11_HOME -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win and ppc_arch == 'p10']
++        - $PREFIX/bin/clang --gcc-toolchain=$GCC_11_HOME -v -fopenmp -I$PREFIX/include -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib omp_hello.c -o omp_hello  # [not win and ppc_arch != 'p10']
+         - '%LIBRARY_BIN%\clang -v -fopenmp -I%LIBRARY_INC% -L%LIBRARY_LIB% omp_hello.c -o omp_hello.exe'   # [win]
+         - ./omp_hello            # [unix]
+         - '%cd%\omp_hello.exe'   # [win]
+-- 
+2.34.1
+

--- a/envs/feedstock-patches/scipy/0001-Fix-build-for-P10.patch
+++ b/envs/feedstock-patches/scipy/0001-Fix-build-for-P10.patch
@@ -1,0 +1,31 @@
+From e71235117b1405a9dbf017273d6c52e568229ab4 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Thu, 14 Jul 2022 12:04:48 +0000
+Subject: [PATCH] Fix build for P10
+
+---
+ recipe/meta.yaml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 69b25be..fff0e1d 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -38,11 +38,11 @@ requirements:
+     - numpy                                  # [build_platform != target_platform]
+     - pybind11                               # [build_platform != target_platform]
+     - setuptools <60                         # [build_platform != target_platform]
+-    - {{ compiler('c') }}
+-    - {{ compiler('cxx') }}
++    - {{ compiler('c') }}                    # [ ppc_arch != "p10"]
++    - {{ compiler('cxx') }}                  # [ ppc_arch != "p10"]
+     # pythran code needs clang-cl on windows
+     - clang                                  # [win]
+-    - {{ compiler('fortran') }}              # [unix]
++    - {{ compiler('fortran') }}              # [unix and ppc_arch != "p10"]  
+     # WARNING: It's not recommended to use these MinGW compilers with python extensions
+     # numpy.distutils has a complex mechanism to facilitate mixing gfortran and MSVC
+     # https://pav.iki.fi/blog/2017-10-08/pywingfortran.html#building-python-wheels-with-fortran-for-windows
+-- 
+2.34.1
+

--- a/envs/onnx-env.yaml
+++ b/envs/onnx-env.yaml
@@ -19,7 +19,10 @@ packages:
   - feedstock : cudnn
   - feedstock : nccl
   {% endif %}
-  - feedstock : pybind11
+  - feedstock : https://github.com/conda-forge/pybind11-feedstock
+    git_tag : 3d3cbe7e8422e78a1c315004ed14480e00f30b59
+    patches :
+      - feedstock-patches/pybind11/pybind11_p10.patch
   - feedstock : onnxruntime
   - feedstock : onnxconverter-common
   - feedstock : skl2onnx

--- a/envs/openblas-env.yaml
+++ b/envs/openblas-env.yaml
@@ -6,11 +6,13 @@ packages:
     git_tag : 66ced78b8653ae9064e404386ac2c48285330774
     patches:
       - feedstock-patches/llvm/0001-LLVM-fixed-with-old-compiler.patch
+      - feedstock-patches/llvm/0001-Fix-build-for-P10.patch
   - feedstock : https://github.com/conda-forge/clangdev-feedstock
     git_tag : b741c7551b48482d08d2f65a791b7602c1f23c9d
     patches :
       - feedstock-patches/clang/0001-Fix-clang-build-with-GCC-11.patch
       - feedstock-patches/clang/0001-Build-fixed-with-old-compilers-and-new-libgcc-ng.patch
+      - feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
   - feedstock : https://github.com/conda-forge/openmp-feedstock
     git_tag: dacfb2acd36a6453e20d71d11f1b85fa6122c649
     patches:

--- a/envs/openblas-env.yaml
+++ b/envs/openblas-env.yaml
@@ -18,5 +18,6 @@ packages:
     patches:
       - feedstock-patches/openmp/0001-remove-dep-on-openmp_mutex.patch
       - feedstock-patches/openmp/0002-disable-LIBOMPTARGET-to-fix-build-on-baremetal.patch
+      - feedstock-patches/openmp/0003-P10-changes.patch
   - feedstock : openblas
 {% endif %}

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -23,4 +23,5 @@ packages:
     git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches:                                                           # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/h5py/0001-Fixed-h5py.patch                   # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-P10-changes.patch                  # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : opencv   # [not s390x]

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -25,3 +25,4 @@ packages:
       - feedstock-patches/h5py/0001-Fixed-h5py.patch                   # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/h5py/0001-P10-changes.patch                  # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : opencv   # [not s390x]
+  - feedstock : cudatoolkit-dev     # [build_type == 'cuda']

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -14,6 +14,7 @@ packages:
     git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches:                                                           # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/h5py/0001-Fixed-h5py.patch                   # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-P10-changes.patch                  # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : https://github.com/conda-forge/scipy-feedstock.git     # [build_type == 'cpu' or cudatoolkit == '11.4']
     git_tag : fec6edcac1ba695a0b61a9de62104fabc267076e                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches :                                                          # [build_type == 'cpu' or cudatoolkit == '11.4']

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -10,7 +10,7 @@ packages:
   - feedstock : cudnn
   - feedstock : cudatoolkit    #[cudatoolkit == "11.2" or cudatoolkit == "11.4"]
   {% endif %}
-  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock      #[build_type == 'cpu' or cudatoolkit == "11.4"]
+  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock      # [build_type == 'cpu' or cudatoolkit == "11.4"]
     git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches:                                                           # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/h5py/0001-Fixed-h5py.patch                   # [build_type == 'cpu' or cudatoolkit == '11.4']
@@ -18,7 +18,7 @@ packages:
     git_tag : fec6edcac1ba695a0b61a9de62104fabc267076e                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches :                                                          # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/scipy/0001-fix-to-build-with-opence.patch    # [build_type == 'cpu' or cudatoolkit == '11.4']
-      - feedstock-patches/scipy/0001-Fix-build-for-P10.patch
+      - feedstock-patches/scipy/0001-Fix-build-for-P10.patch           # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : https://github.com/AnacondaRecipes/absl-py-feedstock
     patches : 
       - feedstock-patches/absl-py/0001-Updated-to-1.0.0.patch

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -18,6 +18,7 @@ packages:
     git_tag : fec6edcac1ba695a0b61a9de62104fabc267076e                 # [build_type == 'cpu' or cudatoolkit == '11.4']
     patches :                                                          # [build_type == 'cpu' or cudatoolkit == '11.4']
       - feedstock-patches/scipy/0001-fix-to-build-with-opence.patch    # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/scipy/0001-Fix-build-for-P10.patch
   - feedstock : https://github.com/AnacondaRecipes/absl-py-feedstock
     patches : 
       - feedstock-patches/absl-py/0001-Updated-to-1.0.0.patch
@@ -31,11 +32,13 @@ packages:
     git_tag : 66ced78b8653ae9064e404386ac2c48285330774
     patches:
       - feedstock-patches/llvm/0001-LLVM-fixed-with-old-compiler.patch
+      - feedstock-patches/llvm/0001-Fix-build-for-P10.patch
   - feedstock : https://github.com/conda-forge/clangdev-feedstock
     git_tag : b741c7551b48482d08d2f65a791b7602c1f23c9d
     patches :
       - feedstock-patches/clang/0001-Fix-clang-build-with-GCC-11.patch
       - feedstock-patches/clang/0001-Build-fixed-with-old-compilers-and-new-libgcc-ng.patch
+      - feedstock-patches/clang/0001-Fixed-clang-for-P10.patch
   - feedstock : keras
   - feedstock : tensorflow
   - feedstock : dm-tree


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

- Update wasabi pin to resolve the following pip check failure observed for spacy:
  `spacy 3.3.1 has requirement wasabi<1.1.0,>=0.9.1, but you have wasabi 0.8.2.`

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
