### PR TITLE
update pins for OpenCE 1.5.6

### DIFF
--- a/.github/actions/feedstock-required-pr/action.yml
+++ b/.github/actions/feedstock-required-pr/action.yml
@@ -28,5 +28,5 @@ runs:
         open-ce validate config \
                          ${env_path}/*-env.yaml \
                          --build_types cuda,cpu \
-                         --python_versions 3.7,3.8,3.9 \
+                         --python_versions 3.8,3.9 \
                          --repository_folder ../

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -33,7 +33,7 @@ jobs:
           # Use yamllint to check the actual yaml files.
           yamllint .github/actions/*/*.yml .github/workflows/*.yml
           yamllint ./envs/conda_build_config.yaml
-          pip install git+https://github.com/open-ce/open-ce-builder.git@main
+          pip install git+https://github.com/open-ce/open-ce-builder.git@v9.0.1
           # Use the conda_build api to lint the env files since they use jinja.
           open-ce validate env envs/*-env.yaml
           # Validate conda_build_config for the main open-ce env file.

--- a/.github/workflows/env-tests.yml
+++ b/.github/workflows/env-tests.yml
@@ -40,6 +40,6 @@ jobs:
           open-ce validate config --conda_build_config \
                                             ./envs/conda_build_config.yaml \
                                             ./envs/*-env.yaml \
-                                            --python_versions 3.7,3.8,3.9 \
+                                            --python_versions 3.8,3.9 \
                                             --build_types cuda,cpu \
                                             --mpi_types openmpi,system

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -236,7 +236,7 @@ python:
 pytorch:
   - 1.10.*
 pytorch_lightning:
-  - 1.5.*
+  - 1.6.*
 pyyaml:
   - 5.*   # [not s390x]
   - 6.*   # [s390x]
@@ -298,7 +298,7 @@ thinc:
 tokenizers:
   - 0.10.3
 torchmetrics:
-  - 0.6.*
+  - 0.8.*
 torchtext:
   - 0.11.*
 torchvision:
@@ -308,7 +308,7 @@ tqdm:
 typer:
   - 0.4.0
 typing_extensions:
-  - 3.7.4.*
+  - 4.1.*
 unzip:
   - 6.0
 wasabi:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

- Updates pins for OpenCE 1.5.6. 
- pytorch-lightning v1.6.5 requires `typing-extensions>=4.0.0, <4.2.1` https://github.com/Lightning-AI/lightning/blob/1.6.5/requirements/base.txt#L10, so updated typing_extensions pin to 4.1.*.

`thinc v8.0.*` requires `typing_extensions >=3.7.4.1,<4.0.0.0` for `python < 3.8` (https://github.com/explosion/thinc/blob/v8.0.15/requirements.txt#L15) hence removing python 3.7 support for OpenCE 1.5.6. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
