### PR TITLE
Some more fixes

### DIFF
--- a/envs/feedstock-patches/uvicorn/0001-Removed-skip-build-for-py310.patch
+++ b/envs/feedstock-patches/uvicorn/0001-Removed-skip-build-for-py310.patch
@@ -1,0 +1,24 @@
+From e918cbc43deb6baa6e115911f7f8fa60d8f6ec11 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Wed, 21 Sep 2022 13:18:29 +0000
+Subject: [PATCH] Removed skip build for py310
+
+---
+ recipe/meta.yaml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index c722092..b1e851b 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -13,7 +13,6 @@ build:
+   script: {{ PYTHON }} -m pip install . -vv
+   entry_points:
+     - uvicorn = uvicorn.main:main
+-  skip: true # [py<=37]
+ 
+ requirements:
+   host:
+-- 
+2.34.1
+

--- a/envs/ray-env.yaml
+++ b/envs/ray-env.yaml
@@ -2,14 +2,12 @@ builder_version: ">=10.0.1"
 
 imported_envs:
 {% if not s390x %}
-{% if build_type == 'cpu' %}
   - arrow-env.yaml
   - tensorflow-env.yaml
   - scipy-env.yaml
 {% endif %}
 
 packages:
-{% if build_type == 'cpu' %}
 {% set py = python | replace(".", "") | int %}
 {% if py >= 310 %}
   - feedstock : https://github.com/AnacondaRecipes/uvicorn-feedstock.git
@@ -32,7 +30,5 @@ packages:
     git_tag : 7e7e8d4a74719ba7ce134ecf7b317c44c1cf39a9
   - feedstock : dm-tree
   - feedstock : ray-packages
-{% endif %}
-{% endif %}
 
 git_tag_for_env: open-ce-v1.7.2


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
1. Change in ray-env.yaml is to enable ray-packages-feedstock automatic tagging . This is a temporary fix, we need to investigate more on why jinja condition of `{% build_type == cpu %}` is not being interpreted rightly when the env is loaded during automatic tagging process.
2. Patch added for uvicorn is needed so that for py3.10 uvicorn package is built. Again here, for some reason, for python version 3.10, py value isn't right and hence the build was being skipped for py3.10. And uvicorn isn't available for py 3.10 on anaconda's channel.


## Review process to land 

1. All tests and other checks must succeed.
3. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
4. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
