### PR TITLE
update numba patch for py38

### DIFF
--- a/envs/feedstock-patches/numba/0001-update-to-numba-0.56.1-and-support-numpy-1.23.patch
+++ b/envs/feedstock-patches/numba/0001-update-to-numba-0.56.1-and-support-numpy-1.23.patch
@@ -1,14 +1,14 @@
-From 0cce5c2a6f3df5b06f55ea50c286a9a70fbae6a6 Mon Sep 17 00:00:00 2001
+From d94ae897fd4428977b175e619f573f48af6619a2 Mon Sep 17 00:00:00 2001
 From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Tue, 20 Sep 2022 10:19:43 +0000
+Date: Thu, 22 Sep 2022 04:37:05 +0000
 Subject: [PATCH] update to numba 0.56.1 and support numpy 1.23
 
 ---
- recipe/meta.yaml | 20 +++++++++-----------
- 1 file changed, 9 insertions(+), 11 deletions(-)
+ recipe/meta.yaml | 21 ++++++++++-----------
+ 1 file changed, 10 insertions(+), 11 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index b051462..d6cbf27 100644
+index b051462..a96fb64 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -1,6 +1,6 @@
@@ -29,7 +29,7 @@ index b051462..d6cbf27 100644
  
  build:
    number: 0
-@@ -41,14 +39,14 @@ requirements:
+@@ -41,16 +39,17 @@ requirements:
      - pip
      - setuptools
      - wheel
@@ -47,8 +47,11 @@ index b051462..d6cbf27 100644
 +    - numpy {{ numpy }}
      # needed for pkg_resources
      - setuptools
++    - importlib_metadata       # [py<39]
  
-@@ -60,16 +58,16 @@ requirements:
+   run_constrained:
+     - tbb  >=2021.0
+@@ -60,16 +59,16 @@ requirements:
      - cudatoolkit >=9.2   # [x86 and not osx]
      - cudatoolkit >=9.0   # [x86 and osx]
      # scipy 1.0 or later


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Update numba patch as numba requires `importlib_metadata` for python 3.8. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
