### PR TITLE
Downgrade setuptools-rust for cuda 11.2

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -258,9 +258,11 @@ regex:
 reproc_cpp:
   - 14.2.*
 rust:
-  - 1.60.*
+  - 1.62.*     # [cudatoolkit == '11.2']
+  - 1.60.*     # [build_type == 'cpu' or cudatoolkit == '11.4']
 rust_compiler_version:
-  - '1.60.0'
+  - '1.46.0'   # [cudatoolkit == '11.2']
+  - '1.60.0'   # [build_type == 'cpu' or cudatoolkit == '11.4']
 safeint:
   - 3.0
 scipy:
@@ -271,7 +273,8 @@ setuptools:
   - 58.*    # [cudatoolkit == '11.2']
   - 63.*    # [build_type == 'cpu' or cudatoolkit == '11.4']
 setuptools_rust:
-  - 1.5.*
+  - 0.12.*    # [cudatoolkit == '11.2']
+  - 1.5.*     # [build_type == 'cpu' or cudatoolkit == '11.4']
 six:
   - 1.16.0
 smart_open:

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -2,16 +2,21 @@ builder_version: ">=10.0.1"
 
 packages:
 {% if not s390x %}
-  - feedstock : https://github.com/conda-forge/rust-feedstock
-    git_tag : 97bf9eebc206d17594013dd0e89938f6536a783a     # 1.60
-    patches :
-      - feedstock-patches/rust/0001-Fixed-build.patch
-  - feedstock : https://github.com/conda-forge/rust-activation-feedstock
-    git_tag : 75803486a2dbca1b39b2a0594b682afaabcb5b13
-    patches :
-      - feedstock-patches/rust-activation/0001-Fixed-build.patch
-  - feedstock : https://github.com/conda-forge/setuptools-rust-feedstock
-    git_tag : 99db82b53099cbc1315238c835f3ad6bc7413774
+  - feedstock : https://github.com/conda-forge/rust-feedstock     # [build_type == 'cpu' or cudatoolkit == '11.4']
+    git_tag : 97bf9eebc206d17594013dd0e89938f6536a783a            # [build_type == 'cpu' or cudatoolkit == '11.4']
+    patches :                                                     # [build_type == 'cpu' or cudatoolkit == '11.4'] 
+      - feedstock-patches/rust/0001-Fixed-build.patch             # [build_type == 'cpu' or cudatoolkit == '11.4']
+  - feedstock : https://github.com/conda-forge/rust-activation-feedstock # [build_type == 'cpu' or cudatoolkit == '11.4']
+    git_tag : 75803486a2dbca1b39b2a0594b682afaabcb5b13            # [build_type == 'cpu' or cudatoolkit == '11.4']
+    patches :                                                     # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/rust-activation/0001-Fixed-build.patch  # [build_type == 'cpu' or cudatoolkit == '11.4']
+  - feedstock : https://github.com/conda-forge/setuptools-rust-feedstock # [build_type == 'cpu' or cudatoolkit == '11.4']
+    git_tag : 99db82b53099cbc1315238c835f3ad6bc7413774            # [build_type == 'cpu' or cudatoolkit == '11.4']
+
+  - feedstock : https://github.com/conda-forge/rust-feedstock.git # [cudatoolkit == '11.2']
+    git_tag : 429557ee73ad0f98221df7260733506ac03d30ae            # [cudatoolkit == '11.2']
+    patches :                                                     # [cudatoolkit == '11.2']
+      - feedstock-patches/rust/0001-Fixed-build.patch                # [cudatoolkit == '11.2']
   - feedstock : tokenizers
   - feedstock : huggingface_hub
   - feedstock : sacremoses


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Downgraded setuptools_rust and rust to whatever it was in previous release for cuda 11.2. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
