### PR TITLE
pin tbb to fix numba build

### DIFF
--- a/envs/feedstock-patches/numba/0001-update-to-numba-0.56.1-and-support-numpy-1.23.patch
+++ b/envs/feedstock-patches/numba/0001-update-to-numba-0.56.1-and-support-numpy-1.23.patch
@@ -1,14 +1,14 @@
-From d94ae897fd4428977b175e619f573f48af6619a2 Mon Sep 17 00:00:00 2001
+From 7f154fd52e039f0047576f066504952b1e228d19 Mon Sep 17 00:00:00 2001
 From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Thu, 22 Sep 2022 04:37:05 +0000
+Date: Thu, 6 Oct 2022 16:19:16 +0000
 Subject: [PATCH] update to numba 0.56.1 and support numpy 1.23
 
 ---
- recipe/meta.yaml | 21 ++++++++++-----------
- 1 file changed, 10 insertions(+), 11 deletions(-)
+ recipe/meta.yaml | 22 ++++++++++------------
+ 1 file changed, 10 insertions(+), 12 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index b051462..a96fb64 100644
+index b051462..1da0556 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -1,6 +1,6 @@
@@ -29,15 +29,16 @@ index b051462..a96fb64 100644
  
  build:
    number: 0
-@@ -41,16 +39,17 @@ requirements:
+@@ -41,14 +39,14 @@ requirements:
      - pip
      - setuptools
      - wheel
 -    - llvmlite 0.38.*
 -    - numpy
+-    - tbb-devel 2021.*
 +    - llvmlite 0.39.*
 +    - numpy {{ numpy }}
-     - tbb-devel 2021.*
++    - tbb-devel 2021.*,<2021.6
      - _openmp_mutex            # [linux and not ppc64le]
    run:
      - python
@@ -47,11 +48,8 @@ index b051462..a96fb64 100644
 +    - numpy {{ numpy }}
      # needed for pkg_resources
      - setuptools
-+    - importlib_metadata       # [py<39]
  
-   run_constrained:
-     - tbb  >=2021.0
-@@ -60,16 +59,16 @@ requirements:
+@@ -60,16 +58,16 @@ requirements:
      - cudatoolkit >=9.2   # [x86 and not osx]
      - cudatoolkit >=9.0   # [x86 and osx]
      # scipy 1.0 or later


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Pin tbb to avoid the following error:
```
  numba/np/ufunc/tbbpool.cpp:31:2: error: #error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
     31 | #error "TBB version is incompatible, 2021.1 through to 2021.5 required, i.e. 12010 <= TBB_INTERFACE_VERSION < 12060"
        |  ^~~~~
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
