### PR TITLE
Import p10 conda_build_config in opence-p10-env file

### DIFF
--- a/envs/opence-p10-env.yaml
+++ b/envs/opence-p10-env.yaml
@@ -1,5 +1,9 @@
 builder_version: ">=10.0.1"
 
+conda_build_configs:
+  - conda_build_config.yaml
+  - conda_build_config_p10.yaml
+
 imported_envs:
   - openblas-env.yaml
   - onnx-env.yaml


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

This will remove the need of explicit argument specification for P10 builds. One just has to specify `--ppc_arch-p10` for P10 builds after this change.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
