### PR TITLE
Build openssl with enable-md2 flag to fix mamba

### DIFF
--- a/envs/feedstock-patches/openssl/0001-Enable-md2-in-openssl.patch
+++ b/envs/feedstock-patches/openssl/0001-Enable-md2-in-openssl.patch
@@ -1,0 +1,42 @@
+From 57484c2e3298e4dae3ddd1a1ae7c5c004bf90930 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Tue, 1 Nov 2022 09:27:25 +0000
+Subject: [PATCH] Build openssl with enable-md2
+
+---
+ recipe/build.sh  | 1 +
+ recipe/meta.yaml | 6 +++---
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/recipe/build.sh b/recipe/build.sh
+index 8f5f528..0a24b45 100644
+--- a/recipe/build.sh
++++ b/recipe/build.sh
+@@ -9,6 +9,7 @@ _CONFIG_OPTS+=(threads)
+ _CONFIG_OPTS+=(no-ssl2)     # broken, insecure protocol
+ _CONFIG_OPTS+=(no-ssl3)     # broken, insecure protocol
+ _CONFIG_OPTS+=(no-zlib)
++_CONFIG_OPTS+=(enable-md2)
+ 
+ _BASE_CC=$(basename "${CC}")
+ if [[ ${_BASE_CC} == *-* ]]; then
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 76fb7a0..45de9d7 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -42,9 +42,9 @@ requirements:
+ test:
+   requires:
+     - certifi  # [win]
+-    - python 3.7  # [not (osx and arm64)]
+-    - python 3.8  # [osx and arm64]
+-    - six
++    #- python 3.7  # [not (osx and arm64)]
++    #- python 3.8  # [osx and arm64]
++    #- six
+   commands:
+     - copy NUL checksum.txt        # [win]
+     - touch checksum.txt           # [unix]
+-- 
+2.34.1
+

--- a/envs/mamba-env.yaml
+++ b/envs/mamba-env.yaml
@@ -1,6 +1,10 @@
 builder_version: ">=10.0.1"
 
 packages:
+  - feedstock : https://github.com/AnacondaRecipes/openssl-feedstock
+    git_tag : dc1ee81ec35a0a27a9d4e0347df15e91c5a324df
+    patches :
+      - feedstock-patches/openssl/0001-Enable-md2-in-openssl.patch
   - feedstock : https://github.com/conda-forge/cli11-feedstock
     git_tag : a8e959fcae876db93c92918e57914f632feac574
   - feedstock : https://github.com/conda-forge/pybind11-feedstock


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

We need to build openssl with `enable-md2` flag so that mamba build works with. Otherwise we see the following error -
```
ImportError: /usr/lib64/librpmio.so.8: undefined symbol: EVP_md2, version OPENSSL_1_1_0

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
