### PR TITLE
Fixed install time conflict issue on s390x

### DIFF
--- a/envs/feedstock-patches/mpi/0001-Build-mpi-for-only-openmpi-type-and-not-for-mpich.patch
+++ b/envs/feedstock-patches/mpi/0001-Build-mpi-for-only-openmpi-type-and-not-for-mpich.patch
@@ -1,0 +1,21 @@
+From 01501a159de8ff220092ac32d211e904bd844bbf Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Mon, 12 Dec 2022 17:23:58 +0000
+Subject: [PATCH] Build mpi for only openmpi type and not for mpich
+
+---
+ recipe/conda_build_config.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/recipe/conda_build_config.yaml b/recipe/conda_build_config.yaml
+index a211d05..2866eb5 100644
+--- a/recipe/conda_build_config.yaml
++++ b/recipe/conda_build_config.yaml
+@@ -1,3 +1,3 @@
+ mpi:
+   - openmpi
+-  - mpich
++#  - mpich           # Disable it for now
+-- 
+2.34.1
+

--- a/envs/lightgbm-env.yaml
+++ b/envs/lightgbm-env.yaml
@@ -7,6 +7,8 @@ packages:
 {% if s390x %}
   - feedstock : https://github.com/AnacondaRecipes/mpi-feedstock
     git_tag: ec3ef9f3f74bdd8b4165af560d056b85df04ae4a
+    patches:
+      - feedstock-patches/mpi/0001-Build-mpi-for-only-openmpi-type-and-not-for-mpich.patch
 {% endif %}
 {% if build_type == 'cuda' %}
   - feedstock : cudatoolkit    #[cudatoolkit == "11.2" or cudatoolkit == "11.4"]


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The issue was coming due to `mpi 1.0 mpich` entry in conda env file whereas openmpi package was built with `mpi 1.0 openmpi`. This was causing install time conflict while conda env creation. So, as a fix, we have disabled mpi build for `mpich` variant. 

Ideally `mpi 1.0 mpich` and `mpi 1.0 openmpi` both entries should have been written in conda env files as mpi package for both variants is built in the output folder. But builder code overwrites `mpi 1.0 openmpi` with `mpi 1.0 mpich` assuming both are same (build string is not accounted while comparing packages to be written into conda env files). Also, this issue recreation depends on the order of the packages being traversed by build-tree. So, it may not reproduce every time. Hence, we also need to address this kind of scenario in builder code itself, which I'll check later. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
