### PR TITLE
Enable more conda packages for s390x

### DIFF
--- a/envs/feedstock-patches/coremltools/0001-coremltools-recipe.patch
+++ b/envs/feedstock-patches/coremltools/0001-coremltools-recipe.patch
@@ -1,0 +1,26 @@
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 8e74dc1..fd9422e 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -25,17 +25,17 @@ requirements:
+     - {{ compiler('c') }}
+     - {{ compiler('cxx') }}
+   host:
+-    - python
+-    - numpy
++    - python {{ python }}
++    - numpy {{ numpy }}
+     - pip
+   run:
+-    - python
++    - python {{ python }}
+     - {{ pin_compatible('numpy') }}
+     - protobuf >=3.1.0
+     - six >=1.1.0
+     - attrs
+     - sympy
+-    - scipy
++    - scipy {{ scipy }}
+     - tqdm
+     - packaging
+   run_constrained:

--- a/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
+++ b/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
@@ -1,0 +1,22 @@
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index fc916e2..6e3583b 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -18,13 +18,13 @@ build:
+ requirements:
+   host:
+     - pip
+-    - python >=3.7
++    - python {{ python }}
+   run:
+-    - python >=3.7
++    - python {{ python }}
+     - scikit-learn >=0.23.0
+-    - scipy >=1.5.1
++    - scipy {{ scipy }}
+     - pandas >=1.1.4
+-    - numpy >=1.18.1
++    - numpy {{ numpy }}
+ 
+ test:
+   imports:

--- a/envs/misc-env.yaml
+++ b/envs/misc-env.yaml
@@ -1,0 +1,13 @@
+builder_version: ">=10.0.1"
+
+packages:
+  - feedstock : https://github.com/conda-forge/sklearn-pandas-feedstock
+    git_tag: 17481bc0c6a7fec33453ed787b3357769b13e195
+    patches:
+      - feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
+{% if s390x %}
+  - feedstock : https://github.com/conda-forge/coremltools-feedstock
+    git_tag: e546cec25f1a70b77c7dfec14725bab1f2b6b33c
+    patches:
+      - feedstock-patches/coremltools/0001-coremltools-recipe.patch
+{% endif %}

--- a/envs/onnx-env.yaml
+++ b/envs/onnx-env.yaml
@@ -1,14 +1,16 @@
 builder_version: ">=10.0.1"
 
+{% if not s390x %}
 imported_envs:
   - tensorflow-env.yaml
+{% endif %}
 
 packages:
+  - feedstock : onnx
 {% if not s390x %}
   - feedstock : safeint
   - feedstock : gtest
   - feedstock : libdate
-  - feedstock : onnx
   - feedstock : optional-lite
   - feedstock : boost_mp11
   - feedstock : https://github.com/conda-forge/fire-feedstock

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -18,6 +18,7 @@ imported_envs:
   - mamba-env.yaml
   - ray-env.yaml
   - apache-beam-env.yaml
+  - misc-env.yaml
 
 packages:
   - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[(build_type == 'cpu' or cudatoolkit == "11.4") and not s390x]

--- a/envs/uwsgi-env.yaml
+++ b/envs/uwsgi-env.yaml
@@ -6,10 +6,10 @@ packages:
     git_tag: 5c2760222698c28ecf9d5608f94d9cdcaa2d9cb8  #2.13.1
     patches:
       - feedstock-patches/jansson/0001-Open-CE-changes.patch
+{% endif %}
   - feedstock: http://github.com/conda-forge/uwsgi-feedstock
     git_tag: 810642a204a7332afc1376aaceb357fa59938b02  #2.0.20
     patches:
       - feedstock-patches/uwsgi/0001-disable-lto-adjust-pins.patch
-{% endif %}
 
 git_tag_for_env: open-ce-v1.7.4


### PR DESCRIPTION
Only onnx is enabled. onnxruntime is not enabled currently.

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Enable onnx conda package for s390x. Only onnx is enabled. onnxruntime is currently not being enabled for s390x.
Also enable uswgi,sklearn-pandas, coremltools conda packages for s390x. Enable sklearn-pandas for other architectures also.

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
