### PR TITLE
Fixed runtime conflict due to sklearn-pandas

### DIFF
--- a/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
+++ b/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
@@ -1,5 +1,14 @@
+From 66574a95c4448c8e69ca554aa53eaa449bc9c321 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Mon, 30 Jan 2023 07:38:42 -0500
+Subject: [PATCH] Open-ce changes
+
+---
+ recipe/meta.yaml | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index fc916e2..6e3583b 100644
+index fc916e2..447317e 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -18,13 +18,13 @@ build:
@@ -7,10 +16,10 @@ index fc916e2..6e3583b 100644
    host:
      - pip
 -    - python >=3.7
-+    - python {{ python }}
++    - python
    run:
 -    - python >=3.7
-+    - python {{ python }}
++    - python
      - scikit-learn >=0.23.0
 -    - scipy >=1.5.1
 +    - scipy {{ scipy }}
@@ -20,3 +29,6 @@ index fc916e2..6e3583b 100644
  
  test:
    imports:
+-- 
+2.23.0
+


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixed gen-license issue with Open-CE 1.7.4. Conda env creation was giving conflicts as sklearn-pandas inspite of being noarch package had pinned python version.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
