### PR TITLE
use patch for uvicorn in pytorch-extras-env too

### DIFF
--- a/envs/pytorch-extras-env.yaml
+++ b/envs/pytorch-extras-env.yaml
@@ -27,6 +27,9 @@ packages:
     git_tag : ffb018797625d7f932bdd2f608d4f0813e227065
   - feedstock : https://github.com/AnacondaRecipes/uvicorn-feedstock.git
     git_tag: 312dca71c6d5a752ad6a2ab7c0a65a55b71a3e81
+    patches:
+      - feedstock-patches/uvicorn/0001-remove-unicode-char-from-summary.patch
+      - feedstock-patches/uvicorn/0001-Removed-skip-build-for-py310.patch
   - feedstock : https://github.com/conda-forge/croniter-feedstock
     git_tag : e2dc0fa0b913d440ffd8806e2b1c61206aefe660
   - feedstock : https://github.com/conda-forge/s3fs-feedstock


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

attempt to fix the gen license failure observed with cuda 11.2 build.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
