### PR TITLE
fix pystan build failure

### DIFF
--- a/envs/feedstock-patches/pystan/0001-pin-scipy-for-tests.patch
+++ b/envs/feedstock-patches/pystan/0001-pin-scipy-for-tests.patch
@@ -1,6 +1,6 @@
-From 55e0da520c257f818e9a2a9800d00419254cdd22 Mon Sep 17 00:00:00 2001
-From: ArchanaShinde1 <archana.shinde2504@gmail.com>
-Date: Wed, 1 Mar 2023 07:10:33 +0000
+From 58336aee864988b0a772c41d31145ded2b4298ef Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Wed, 1 Mar 2023 08:11:27 +0000
 Subject: [PATCH] pin scipy for tests
 
 ---

--- a/envs/feedstock-patches/pystan/0001-pin-scipy-for-tests.patch
+++ b/envs/feedstock-patches/pystan/0001-pin-scipy-for-tests.patch
@@ -1,0 +1,25 @@
+From 55e0da520c257f818e9a2a9800d00419254cdd22 Mon Sep 17 00:00:00 2001
+From: ArchanaShinde1 <archana.shinde2504@gmail.com>
+Date: Wed, 1 Mar 2023 07:10:33 +0000
+Subject: [PATCH] pin scipy for tests
+
+---
+ recipe/meta.yaml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index d267944..f4d1556 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -47,6 +47,8 @@ requirements:
+     - libpython  # [win]
+ 
+ test:
++  requires:
++    - scipy 1.9.3
+   imports:
+     - pystan
+ 
+-- 
+2.34.1
+

--- a/envs/orbit-ml-env.yaml
+++ b/envs/orbit-ml-env.yaml
@@ -9,8 +9,6 @@ packages:
 {% if not s390x %}
   - feedstock : https://github.com/conda-forge/pyro-api-feedstock
     git_tag : 5943002669cb56ec550fcfad6657aa1a6d8b2637
-  - feedstock : https://github.com/conda-forge/opt_einsum-feedstock
-    git_tag : 861d394ac99f0e5460b7d9f271a6e7117c6498cc
   - feedstock : https://github.com/conda-forge/arviz-feedstock
     git_tag : edbe33e75097a3ad894f863495a8653d26b10f27
   - feedstock : https://github.com/conda-forge/xarray-einstats-feedstock
@@ -19,12 +17,10 @@ packages:
     git_tag : a0c3ebcb2f652254da2f08f4b87b113d912ee7df
     patches :
       - feedstock-patches/pyro-ppl/0001-pin-pytorch-in-recipe.patch
-  - feedstock : https://github.com/conda-forge/pystan-feedstock
-    git_tag : daf41a0b355802b7d8dcd9df383e9d39d5090b80
-  - feedstock : https://github.com/AnacondaRecipes/libnetcdf-feedstock
-    git_tag: 2e504dea87602cd3ea50fc54b7ed5f13dd705290
-    patches :
-      - feedstock-patches/libnetcdf/0001-remove-git-as-it-is-causing-conflicts.patch
+  - feedstock : https://github.com/conda-forge/pystan-feedstock          #[py >= 310]
+    git_tag : daf41a0b355802b7d8dcd9df383e9d39d5090b80                   #[py >= 310]
+    patches :                                                            #[py >= 310]
+      - feedstock-patches/pystan/0001-pin-scipy-for-tests.patch          #[py >= 310]
   - feedstock : https://github.com/conda-forge/orbit-ml-feedstock.git
     git_tag : 7de16c99ec18e3474b11e458de69493d10b92eae
     patches :


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Adding patch to use `scipy v1.9.3` in pystan test section to avoid seg fault with the test script. 
Also removed some no-longer needed feedstocks from orbit-ml env as these are available on Anaconda's default channel.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
