### PR TITLE
Disabled ray for FIPS enabled builds

### DIFF
--- a/envs/opence-fips-env.yaml
+++ b/envs/opence-fips-env.yaml
@@ -1,0 +1,36 @@
+builder_version: ">=10.0.1"
+
+imported_envs:
+  - openblas-env.yaml
+  - onnx-env.yaml
+  - pytorch-env.yaml
+  - pytorch-extras-env.yaml
+  - pytorch_geometric-env.yaml
+  - tensorflow-env.yaml
+  - xgboost-env.yaml
+  - dali-env.yaml
+  - spacy-env.yaml
+  - transformers-env.yaml
+  - horovod-env.yaml
+  - lightgbm-env.yaml
+  - arrow-env.yaml
+  - uwsgi-env.yaml
+  - mamba-env.yaml
+  # Disabling ray in FIPS enabled builds due to an error in cython on FIPS enabled system.
+  # Cause of error is hashlib.md5() in cython library
+  #- ray-env.yaml    
+  - apache-beam-env.yaml
+  - misc-env.yaml
+
+packages:
+  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[(build_type == 'cpu' or cudatoolkit == "11.4") and not s390x]
+    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9   # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
+    patches:                                             # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
+      - feedstock-patches/h5py/0001-Fixed-h5py.patch     # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
+      - feedstock-patches/h5py/0001-P10-changes.patch    # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]              
+  - feedstock : opencv   # [not s390x]
+  - feedstock : cudatoolkit-dev     # [build_type == 'cuda']
+  - feedstock : https://github.com/AnacondaRecipes/zlib-feedstock   # [cudatoolkit == '11.2']
+    git_tag : 30371b0c9c707927c900bd49ca1ec39d3c3e8e0f               # [cudatoolkit == '11.2']
+
+git_tag_for_env: open-ce-v1.7.7


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Disabled ray for FIPS builds as it is giving errors during the build, on a FIPS enabled system. The error is coming from cython library. Hence, for now, we are disabling ray as it is  not used by FIPS customers.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
