### PR TITLE
build ffmpeg for fips with openssl

### DIFF
--- a/envs/feedstock-patches/ffmpeg/0001-disable-codecs-for-opence.patch
+++ b/envs/feedstock-patches/ffmpeg/0001-disable-codecs-for-opence.patch
@@ -1,20 +1,35 @@
-From 9501c16fc56452d7cf617f3e74ce62de2ecb0428 Mon Sep 17 00:00:00 2001
+From adb926a278a2aab0319af79fa2f25223428aff59 Mon Sep 17 00:00:00 2001
 From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Tue, 9 May 2023 08:10:04 +0000
+Date: Fri, 12 May 2023 06:25:42 +0000
 Subject: [PATCH] disable codecs for opence
 
 ---
- recipe/build.sh  | 20 ++++++++++++++++++--
- recipe/meta.yaml |  8 +-------
- 2 files changed, 19 insertions(+), 9 deletions(-)
+ recipe/build.sh  | 27 ++++++++++++++++++++++-----
+ recipe/meta.yaml | 10 +---------
+ 2 files changed, 23 insertions(+), 14 deletions(-)
 
 diff --git a/recipe/build.sh b/recipe/build.sh
-index 8528472..f035552 100755
+index 8528472..d7ef169 100755
 --- a/recipe/build.sh
 +++ b/recipe/build.sh
-@@ -26,9 +26,9 @@ else
+@@ -1,4 +1,5 @@
+ #!/bin/bash
++set -ex
+ 
+ # unset the SUBDIR variable since it changes the behavior of make here
+ unset SUBDIR
+@@ -20,15 +21,15 @@ if [[ ${USE_NONFREE} == yes ]]; then
+   _CONFIG_OPTS+=("--enable-libx264")
+ else
+   _CONFIG_OPTS+=("--disable-nonfree")
+-  _CONFIG_OPTS+=("--enable-gpl")
+-  _CONFIG_OPTS+=("--enable-gnutls")
++  _CONFIG_OPTS+=("--disable-gpl")
++  _CONFIG_OPTS+=("--disable-gnutls")
+   # OpenSSL 3 will be Apache-licensed so we can revisit this later:
    # https://github.com/openssl/openssl/commit/151333164ece49fdba3fe5c4bbdc3333cd9ae66d
-   _CONFIG_OPTS+=("--disable-openssl")
+-  _CONFIG_OPTS+=("--disable-openssl")
++  _CONFIG_OPTS+=("--enable-openssl")
    # The Cisco GPL-compliant wrapper (you need to get your own binaries for this)
 -  _CONFIG_OPTS+=("--enable-libopenh264")
 +  _CONFIG_OPTS+=("--disable-libopenh264")
@@ -24,7 +39,7 @@ index 8528472..f035552 100755
  fi
  
  ./configure \
-@@ -50,6 +50,22 @@ fi
+@@ -50,6 +51,22 @@ fi
          --enable-version3 \
          --enable-zlib \
        	--enable-libmp3lame \
@@ -48,10 +63,10 @@ index 8528472..f035552 100755
  
  make -j${CPU_COUNT} ${VERBOSE_AT}
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 23ad810..f3578d0 100644
+index 23ad810..ee65946 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
-@@ -28,7 +28,7 @@ requirements:
+@@ -28,18 +28,15 @@ requirements:
    build:
      - {{ compiler("c") }}
      - {{ compiler("cxx") }}
@@ -60,9 +75,10 @@ index 23ad810..f3578d0 100644
      - libtool  # [not win]
      - nasm  # [(osx and x86_64) or linux32 or linux64]
      - make  # [not win]
-@@ -37,9 +37,7 @@ requirements:
+   host:
+     - bzip2  # [not win]
      - freetype  # [not win]
-     - gnutls  # [not win]
+-    - gnutls  # [not win]
      - libiconv  # [not win and not linux]
 -    - x264  # [not win]
      - zlib  # [not win]
@@ -70,7 +86,7 @@ index 23ad810..f3578d0 100644
      - lame  # [not win]
      - gmp  # [unix]
      - libvpx  # [not win]
-@@ -55,10 +53,6 @@ test:
+@@ -55,16 +52,11 @@ test:
      - ffmpeg -loglevel panic -protocols | grep "https"  # [not win]
      - ffmpeg -loglevel panic -codecs | grep "libmp3lame"  # [not win]
      - ffmpeg -loglevel panic -codecs | grep "DEVI.S zlib"  # [unix]
@@ -80,6 +96,12 @@ index 23ad810..f3578d0 100644
 -    - ffmpeg -loglevel panic -codecs | grep "libopenh264"  # [linux64 or osx64]
      # Verify dynamic libraries on all systems
      {% set ffmpeg_libs = [
+         "avcodec",
+         "avdevice",
+         "swresample",
+-        "postproc",
+         "avfilter",
+         "swresample",
          "avcodec",
 -- 
 2.34.1

--- a/envs/feedstock-patches/ffmpeg/0001-opence-changes-for-build-with-openssl-for-fips.patch
+++ b/envs/feedstock-patches/ffmpeg/0001-opence-changes-for-build-with-openssl-for-fips.patch
@@ -1,0 +1,124 @@
+From 90fb053d9c55eef7ea223e1e5c4a409c530a0218 Mon Sep 17 00:00:00 2001
+From: root <root@dldev7.aus.stglabs.ibm.com>
+Date: Thu, 11 May 2023 05:00:48 -0400
+Subject: [PATCH] opence changes for build with openssl for fips
+
+---
+ recipe/build.sh  | 32 +++++++++++++++++++++++++++-----
+ recipe/meta.yaml | 13 +++----------
+ 2 files changed, 30 insertions(+), 15 deletions(-)
+
+diff --git a/recipe/build.sh b/recipe/build.sh
+index 8528472..887d01b 100755
+--- a/recipe/build.sh
++++ b/recipe/build.sh
+@@ -1,4 +1,5 @@
+ #!/bin/bash
++set -ex
+ 
+ # unset the SUBDIR variable since it changes the behavior of make here
+ unset SUBDIR
+@@ -20,17 +21,22 @@ if [[ ${USE_NONFREE} == yes ]]; then
+   _CONFIG_OPTS+=("--enable-libx264")
+ else
+   _CONFIG_OPTS+=("--disable-nonfree")
+-  _CONFIG_OPTS+=("--enable-gpl")
+-  _CONFIG_OPTS+=("--enable-gnutls")
++  _CONFIG_OPTS+=("--disable-gpl")
++  _CONFIG_OPTS+=("--disable-gnutls")
+   # OpenSSL 3 will be Apache-licensed so we can revisit this later:
+   # https://github.com/openssl/openssl/commit/151333164ece49fdba3fe5c4bbdc3333cd9ae66d
+-  _CONFIG_OPTS+=("--disable-openssl")
++  _CONFIG_OPTS+=("--enable-openssl")
+   # The Cisco GPL-compliant wrapper (you need to get your own binaries for this)
+-  _CONFIG_OPTS+=("--enable-libopenh264")
++  _CONFIG_OPTS+=("--disable-libopenh264")
+   # GPL-3.0
+-  _CONFIG_OPTS+=("--enable-libx264")
++  _CONFIG_OPTS+=("--disable-libx264")
+ fi
+ 
++#export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
++
++#pkg-config --list-all
++#pkg-config gnutls --cflags
++
+ ./configure \
+         --prefix="${PREFIX}" \
+         --cc=${CC} \
+@@ -50,6 +56,22 @@ fi
+         --enable-version3 \
+         --enable-zlib \
+       	--enable-libmp3lame \
++        --disable-encoder=h264 \
++        --disable-decoder=h264 \
++        --disable-decoder=libh264 \
++        --disable-decoder=libx264 \
++        --disable-decoder=libopenh264 \
++        --disable-encoder=libopenh264 \
++        --disable-encoder=libx264 \
++        --disable-decoder=libx264rgb \
++        --disable-encoder=libx264rgb \
++        --disable-encoder=hevc \
++        --disable-decoder=hevc \
++        --disable-encoder=aac \
++        --disable-decoder=aac \
++        --disable-decoder=aac_fixed \
++        --disable-encoder=aac_latm \
++        --disable-decoder=aac_latm \
+         "${_CONFIG_OPTS[@]}"
+ 
+ make -j${CPU_COUNT} ${VERBOSE_AT}
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 23ad810..6aa9a7b 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -28,25 +28,23 @@ requirements:
+   build:
+     - {{ compiler("c") }}
+     - {{ compiler("cxx") }}
+-    - pkg-config  # [not win]
++    - pkg-config {{ pkgconfig }}
+     - libtool  # [not win]
+     - nasm  # [(osx and x86_64) or linux32 or linux64]
+     - make  # [not win]
+   host:
+     - bzip2  # [not win]
+     - freetype  # [not win]
+-    - gnutls  # [not win]
+     - libiconv  # [not win and not linux]
+-    - x264  # [not win]
+     - zlib  # [not win]
+-    - openh264  # [not win]
+     - lame  # [not win]
+     - gmp  # [unix]
+     - libvpx  # [not win]
+     - libopus # [not win]
+-    - openssl # [not win]
++    - openssl 1.1.1zz
+   run:
+     - lame  # [not win]
++    - openssl 1.1.1zz
+ 
+ test:
+   commands:
+@@ -55,16 +53,11 @@ test:
+     - ffmpeg -loglevel panic -protocols | grep "https"  # [not win]
+     - ffmpeg -loglevel panic -codecs | grep "libmp3lame"  # [not win]
+     - ffmpeg -loglevel panic -codecs | grep "DEVI.S zlib"  # [unix]
+-    - ffmpeg -loglevel panic -codecs | grep "DEV.LS h264"  # [linux64 or osx64]
+-    - ffmpeg -loglevel panic -codecs | grep "D.V.LS h264"  # [ppc64le]
+-    - ffmpeg -loglevel panic -codecs | grep "libx264"  # [linux64 or osx64]
+-    - ffmpeg -loglevel panic -codecs | grep "libopenh264"  # [linux64 or osx64]
+     # Verify dynamic libraries on all systems
+     {% set ffmpeg_libs = [
+         "avcodec",
+         "avdevice",
+         "swresample",
+-        "postproc",
+         "avfilter",
+         "swresample",
+         "avcodec",
+-- 
+2.27.0
+

--- a/envs/feedstock-patches/ffmpeg/0001-opence-changes-for-build-with-openssl-for-fips.patch
+++ b/envs/feedstock-patches/ffmpeg/0001-opence-changes-for-build-with-openssl-for-fips.patch
@@ -1,15 +1,15 @@
-From 90fb053d9c55eef7ea223e1e5c4a409c530a0218 Mon Sep 17 00:00:00 2001
-From: root <root@dldev7.aus.stglabs.ibm.com>
-Date: Thu, 11 May 2023 05:00:48 -0400
+From fbc264e18d85e20e7473184eeb1d10e15ce9ff14 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Fri, 12 May 2023 06:06:53 +0000
 Subject: [PATCH] opence changes for build with openssl for fips
 
 ---
- recipe/build.sh  | 32 +++++++++++++++++++++++++++-----
+ recipe/build.sh  | 27 ++++++++++++++++++++++-----
  recipe/meta.yaml | 13 +++----------
- 2 files changed, 30 insertions(+), 15 deletions(-)
+ 2 files changed, 25 insertions(+), 15 deletions(-)
 
 diff --git a/recipe/build.sh b/recipe/build.sh
-index 8528472..887d01b 100755
+index 8528472..d7ef169 100755
 --- a/recipe/build.sh
 +++ b/recipe/build.sh
 @@ -1,4 +1,5 @@
@@ -18,7 +18,7 @@ index 8528472..887d01b 100755
  
  # unset the SUBDIR variable since it changes the behavior of make here
  unset SUBDIR
-@@ -20,17 +21,22 @@ if [[ ${USE_NONFREE} == yes ]]; then
+@@ -20,15 +21,15 @@ if [[ ${USE_NONFREE} == yes ]]; then
    _CONFIG_OPTS+=("--enable-libx264")
  else
    _CONFIG_OPTS+=("--disable-nonfree")
@@ -38,15 +38,8 @@ index 8528472..887d01b 100755
 +  _CONFIG_OPTS+=("--disable-libx264")
  fi
  
-+#export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$PREFIX/lib/pkgconfig
-+
-+#pkg-config --list-all
-+#pkg-config gnutls --cflags
-+
  ./configure \
-         --prefix="${PREFIX}" \
-         --cc=${CC} \
-@@ -50,6 +56,22 @@ fi
+@@ -50,6 +51,22 @@ fi
          --enable-version3 \
          --enable-zlib \
        	--enable-libmp3lame \
@@ -120,5 +113,5 @@ index 23ad810..6aa9a7b 100644
          "swresample",
          "avcodec",
 -- 
-2.27.0
+2.34.1
 

--- a/envs/feedstock-patches/tokenizers/0001-changes-for-opence-fips.patch
+++ b/envs/feedstock-patches/tokenizers/0001-changes-for-opence-fips.patch
@@ -1,14 +1,14 @@
-From 0ee4d342c6c252de6d8478e49e37355b2d5d9f43 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Fri, 28 Apr 2023 09:58:12 +0000
+From a13fec8cc8475d38f9ef00b55e1abf886e029e85 Mon Sep 17 00:00:00 2001
+From: root <root@dldev7.aus.stglabs.ibm.com>
+Date: Thu, 11 May 2023 05:06:54 -0400
 Subject: [PATCH] changes for opence fips
 
 ---
- recipe/meta.yaml | 9 +++++----
- 1 file changed, 5 insertions(+), 4 deletions(-)
+ recipe/meta.yaml | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 004052a..b0f1b74 100644
+index 004052a..d2a7151 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -23,8 +23,8 @@ build:
@@ -43,6 +43,14 @@ index 004052a..b0f1b74 100644
  
  test:
    imports:
+@@ -76,6 +77,7 @@ test:
+     {% set tests_to_skip = "_not_a_real_test" %}
+     # windows and expectation of forking -> not gonna happen
+     {% set tests_to_skip = tests_to_skip + " or with_parallelism" %}  # [win]
++    {% set tests_to_skip = tests_to_skip + " or test_datasets" %}
+     - pytest -v tests -k "not ({{ tests_to_skip }})"
+ 
+ about:
 -- 
-2.34.1
+2.27.0
 

--- a/envs/openssl-env.yaml
+++ b/envs/openssl-env.yaml
@@ -17,7 +17,7 @@ packages:
     patches :
      - feedstock-patches/tokenizers/0001-changes-for-opence-fips.patch
   # overrides the ffmpeg feedstock used in the ffmpeg env.
-  # the patch used here is specific for FIPS build
+  # the patch used here adds a dependency on opence openssl for FIPS build
   - feedstock : https://github.com/AnacondaRecipes/ffmpeg-feedstock
     git_tag : 57ca332013295a161307fa10afdae2197a56cc93
     patches :

--- a/envs/openssl-env.yaml
+++ b/envs/openssl-env.yaml
@@ -16,3 +16,9 @@ packages:
     git_tag : 026e5a6446124a4635e604de2dc3c1a83e66bc08
     patches :
      - feedstock-patches/tokenizers/0001-changes-for-opence-fips.patch
+  # overrides the ffmpeg feedstock used in the ffmpeg env.
+  # the patch used here is specific for FIPS build
+  - feedstock : https://github.com/AnacondaRecipes/ffmpeg-feedstock
+    git_tag : 57ca332013295a161307fa10afdae2197a56cc93
+    patches :
+      - feedstock-patches/ffmpeg/0001-opence-changes-for-build-with-openssl-for-fips.patch


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

This PR adds a patch to build ffmpeg with openssl for fips support. And also skips a test in tokenizers as it failed on fips enabled system due to call to hashlib.md5().

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
