### PR TITLE
Fixed conflicts on s390x due to h5py

### DIFF
--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -21,11 +21,11 @@ imported_envs:
   - misc-env.yaml
 
 packages:
-  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[(build_type == 'cpu' or cudatoolkit == "11.4") and not s390x]
-    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9   # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-    patches:                                             # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-Fixed-h5py.patch     # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-P10-changes.patch    # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]              
+  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[build_type == 'cpu' or cudatoolkit == "11.4"]
+    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9   # [build_type == 'cpu' or cudatoolkit == '11.4']
+    patches:                                             # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-Fixed-h5py.patch     # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-P10-changes.patch    # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : opencv
   - feedstock : cudatoolkit-dev     # [build_type == 'cuda']
   - feedstock : https://github.com/AnacondaRecipes/zlib-feedstock   # [cudatoolkit == '11.2']

--- a/envs/opence-fips-env.yaml
+++ b/envs/opence-fips-env.yaml
@@ -23,12 +23,12 @@ imported_envs:
   - misc-env.yaml
 
 packages:
-  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[(build_type == 'cpu' or cudatoolkit == "11.4") and not s390x]
-    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9   # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-    patches:                                             # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-Fixed-h5py.patch     # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-P10-changes.patch    # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]              
-  - feedstock : opencv   # [not s390x]
+  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[build_type == 'cpu' or cudatoolkit == "11.4"]
+    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9   # [build_type == 'cpu' or cudatoolkit == '11.4']
+    patches:                                             # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-Fixed-h5py.patch     # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-P10-changes.patch    # [build_type == 'cpu' or cudatoolkit == '11.4']
+  - feedstock : opencv
   - feedstock : cudatoolkit-dev     # [build_type == 'cuda']
   - feedstock : https://github.com/AnacondaRecipes/zlib-feedstock   # [cudatoolkit == '11.2']
     git_tag : 30371b0c9c707927c900bd49ca1ec39d3c3e8e0f               # [cudatoolkit == '11.2']

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -13,11 +13,11 @@ packages:
 {% endif %}
   - feedstock : https://github.com/AnacondaRecipes/zlib-feedstock   # [cudatoolkit == '11.2']
     git_tag : 30371b0c9c707927c900bd49ca1ec39d3c3e8e0f               # [cudatoolkit == '11.2']
-  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[(build_type == 'cpu' or cudatoolkit == "11.4") and not s390x]
-    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9    # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-    patches:                                              # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-Fixed-h5py.patch      # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
-      - feedstock-patches/h5py/0001-P10-changes.patch     # [(build_type == 'cpu' or cudatoolkit == '11.4') and not s390x]
+  - feedstock : https://github.com/AnacondaRecipes/h5py-feedstock  #[build_type == 'cpu' or cudatoolkit == "11.4"]
+    git_tag : 4d8e6c1ec80d3dfa1fe78ed4eab0bc22340516f9    # [build_type == 'cpu' or cudatoolkit == '11.4']
+    patches:                                              # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-Fixed-h5py.patch      # [build_type == 'cpu' or cudatoolkit == '11.4']
+      - feedstock-patches/h5py/0001-P10-changes.patch     # [build_type == 'cpu' or cudatoolkit == '11.4']
   - feedstock : https://github.com/AnacondaRecipes/absl-py-feedstock
     git_tag : 85fff27f50229187e7877c434590b01ac42ba772
     patches :


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

h5py was not being on s390x, so it was being pulled from anaconda, which depends on older hdf5. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
