### PR TITLE
Fixed aioredis patch to allow python 3.10.* and 1.9.1 items

### DIFF
--- a/envs/feedstock-patches/aioredis/0001-avoid-using-python-3.11.patch
+++ b/envs/feedstock-patches/aioredis/0001-avoid-using-python-3.11.patch
@@ -1,14 +1,14 @@
-From a032e1d0d9a6d70c2cf786731ff06373daf3bcf4 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Wed, 22 Mar 2023 15:36:20 +0000
-Subject: [PATCH] avoid using python 3.11
+From 8bc1db8d175b84ec929ec5a117ed6867b4affecc Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23in.ibm.com>
+Date: Thu, 1 Jun 2023 10:51:07 +0000
+Subject: [PATCH] Fixed python version
 
 ---
  recipe/meta.yaml | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 451f045..3ed54c8 100644
+index 451f045..4290953 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -17,11 +17,11 @@ build:
@@ -16,12 +16,12 @@ index 451f045..3ed54c8 100644
    host:
      - pip
 -    - python >=3.6
-+    - python <=3.10
++    - python <3.11
    run:
      - async-timeout
      - typing-extensions
 -    - python >=3.6
-+    - python <=3.10
++    - python <3.11
  
  test:
    imports:

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -24,6 +24,7 @@ imported_envs:
   - deepspeed-env.yaml
   - misc-env.yaml
   - or-tools-env.yaml
+  - tensorflow-serving-env.yaml
 
 packages:
   - feedstock : https://github.com/conda-forge/eigen-feedstock.git

--- a/envs/opence-p10-env.yaml
+++ b/envs/opence-p10-env.yaml
@@ -16,6 +16,7 @@ imported_envs:
   - lightgbm-env.yaml
   - arrow-env.yaml
   - or-tools-env.yaml
+  - tensorflow-serving-env.yaml
 
 packages:
   - feedstock : opencv

--- a/envs/tensorflow-env.yaml
+++ b/envs/tensorflow-env.yaml
@@ -38,7 +38,7 @@ packages:
   - feedstock : tensorflow-datasets
   - feedstock : tensorflow-text
   - feedstock : tensorflow-model-optimization
-  - feedstock : tensorflow-addons             #[build_type == 'cpu']
+  - feedstock : tensorflow-addons             #[build_type == 'cpu' or cudatoolkit == '11.2']
   - feedstock : tensorflow-io-gcs-filesystem  # [not s390x]
 
 git_tag_for_env: open-ce-v1.9.0


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes following -
1. Fixed aioredis patch to allow python 3.10.* version
2. Include TF serving env build in opence-env and opence-p10-env files
3. Enabled TF addons for cuda 11.2

## Review process to land 

1. All tests and other checks must succeed.
4. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
5. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
