### PR TITLE
disable pytorch and dependendent packages for cuda 11.2

### DIFF
--- a/envs/deepspeed-env.yaml
+++ b/envs/deepspeed-env.yaml
@@ -1,13 +1,13 @@
 builder_version: ">=10.0.1"
 
 imported_envs:
-{% if build_type == 'cuda' %}
+{% if build_type == 'cuda' and cudatoolkit == '11.8' %}
     - pytorch-env.yaml
 {% endif %}
 
 packages:
 {% if not s390x %}
-  {% if build_type == 'cuda' %}
+  {% if build_type == 'cuda' and cudatoolkit == '11.8' %}
     - feedstock : https://github.com/conda-forge/hjson-py-feedstock
       git_tag: d8a1feb4e5099836efafb19fe449511ef6e8d9a7
     - feedstock : openmpi                  #[mpi_type == 'openmpi']

--- a/envs/horovod-env.yaml
+++ b/envs/horovod-env.yaml
@@ -1,14 +1,14 @@
 builder_version: ">=10.0.1"
 
 imported_envs:
-{% if build_type == 'cuda' %}
+{% if build_type == 'cuda' and cudatoolkit == '11.8' %}
     - pytorch-env.yaml
     - tensorflow-env.yaml
 {% endif %}
 
 packages:
 {% if not s390x %}
-  {% if build_type == 'cuda' %}
+  {% if build_type == 'cuda' and cudatoolkit == '11.8' %}
     - feedstock : horovod
     - feedstock : openmpi #[mpi_type == 'openmpi']
   {% endif %}

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -4,13 +4,13 @@ imported_envs:
   - common-deps.yaml
   - openblas-env.yaml
   - onnx-env.yaml
-  - pytorch-env.yaml
-  - pytorch-extras-env.yaml
+  - pytorch-env.yaml                   # [build_type == 'cpu' or cudatoolkit == '11.8']
+  - pytorch-extras-env.yaml            # [build_type == 'cpu' or cudatoolkit == '11.8']
   - pytorch_geometric-env.yaml         # [build_type == 'cpu' or cudatoolkit == '11.8']
   - tensorflow-env.yaml
   - xgboost-env.yaml
   - dali-env.yaml
-  - horovod-env.yaml
+  - horovod-env.yaml                   # [build_type == 'cpu' or cudatoolkit == '11.8']
   - lightgbm-env.yaml
   - arrow-env.yaml
   - mamba-env.yaml
@@ -19,8 +19,8 @@ imported_envs:
   #- ray-env.yaml
   - apache-beam-env.yaml
   - prophet-env.yaml
-  - orbit-ml-env.yaml
-  - deepspeed-env.yaml
+  - orbit-ml-env.yaml                  # [build_type == 'cpu' or cudatoolkit == '11.8']
+  - deepspeed-env.yaml                 # [build_type == 'cpu' or cudatoolkit == '11.8']
   - misc-env.yaml
   - or-tools-env.yaml
   - tensorflow-serving-env.yaml

--- a/envs/pytorch-env.yaml
+++ b/envs/pytorch-env.yaml
@@ -1,11 +1,14 @@
 builder_version: ">=10.0.1"
 
 imported_envs:
+{% if build_type == 'cpu' or cudatoolkit == '11.8' %}
   - openblas-env.yaml
   - common-p10-deps.yaml      #[ppc_arch == "p10"]
   - common-deps.yaml
+{% endif %}
 
 packages:
+{% if build_type == 'cpu' or cudatoolkit == '11.8' %}
   - feedstock : pytorch
   - feedstock : numactl
   - feedstock : sentencepiece
@@ -25,5 +28,6 @@ packages:
     git_tag: 44dd156fd8f7a81536926e11b54fdbf9df2c3158                     #[ppc_arch == "p10"]
     patches:                                                              #[ppc_arch == "p10"]
       - feedstock-patches/leveldb/0001-changes-for-opence.patch           #[ppc_arch == "p10"]
+{% endif %}
 
 git_tag_for_env: open-ce-v1.9.0

--- a/envs/pytorch-extras-env.yaml
+++ b/envs/pytorch-extras-env.yaml
@@ -1,12 +1,15 @@
 builder_version: ">=10.0.1"
 
 imported_envs:
+{% if build_type == 'cpu' or cudatoolkit == '11.8' %}
   - tensorboard-env.yaml
   - pytorch-env.yaml
   - common-p10-deps.yaml      #[ppc_arch == "p10"]
+{% endif %}
 
 packages:
 {% if not s390x %}
+{% if build_type == 'cpu' or cudatoolkit == '11.8' %}
   - feedstock : pytorch-lightning
   - feedstock : pytorch-lightning-bolts
   - feedstock : libflac
@@ -44,6 +47,7 @@ packages:
       - feedstock-patches/aioredis/0001-avoid-using-python-3.11.patch
   - feedstock : https://github.com/conda-forge/dateutils-feedstock
     git_tag : 2723b1b582889ac1e5f10e8aaf0cb91ff6c41844
+{% endif %}
 {% endif %}
 
 git_tag_for_env: open-ce-v1.9.0


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Disable pytorch and dependent envs for cuda 11.2, because we are seeing conflicts while building PyTorch for cuda 11.2 case.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
