### PR TITLE
Fixed conflicts with cuda 11.2 builds on ppc

### DIFF
--- a/envs/ray-env.yaml
+++ b/envs/ray-env.yaml
@@ -13,8 +13,10 @@ packages:
     patches:
       - feedstock-patches/uvicorn/0001-remove-unicode-char-from-summary.patch
       - feedstock-patches/uvicorn/0001-Removed-skip-build-for-py310.patch
-  - feedstock : https://github.com/AnacondaRecipes/cfitsio-feedstock
-    git_tag: f965e25fdec2b5dee0965cfaf2635384ae8e16ed
+  - feedstock : https://github.com/AnacondaRecipes/cfitsio-feedstock        #[cudatoolkit != '11.2']
+    git_tag: f965e25fdec2b5dee0965cfaf2635384ae8e16ed                       #[cudatoolkit != '11.2']
+    patches:                                                                #[cudatoolkit != '11.2']
+      - feedstock-patches/cfitsio/0001-Open-ce-changes.patch                #[cudatoolkit != '11.2']
   - feedstock : https://github.com/conda-forge/starlette-feedstock
     git_tag : af1e1b369a2327a4a4b7d52a9a8579454729dd07
   - feedstock : https://github.com/conda-forge/python-multipart-feedstock


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

For cuda 11.2 we don't need to build cfitsio as it causes conflicts for libgfortran-ng.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
