### PR TITLE
pin pandas in sklearn-pandas patch

### DIFF
--- a/envs/feedstock-patches/datasets/0001-changes-for-opence.patch
+++ b/envs/feedstock-patches/datasets/0001-changes-for-opence.patch
@@ -1,12 +1,12 @@
-From b6c2fb9ccc405aaa40cf9659907a5d51eee52f90 Mon Sep 17 00:00:00 2001
+From 5946bfdd20ebcf54e6444f7a233e687cb7ab43ff Mon Sep 17 00:00:00 2001
 From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Fri, 15 Sep 2023 06:57:00 +0000
+Date: Tue, 17 Oct 2023 10:37:07 +0000
 Subject: [PATCH] changes for opence
 
 ---
  recipe/0001-Fix-for-FIPS.patch | 25 +++++++++++++++++++++++++
- recipe/meta.yaml               |  8 +++++---
- 2 files changed, 30 insertions(+), 3 deletions(-)
+ recipe/meta.yaml               | 10 ++++++----
+ 2 files changed, 31 insertions(+), 4 deletions(-)
  create mode 100644 recipe/0001-Fix-for-FIPS.patch
 
 diff --git a/recipe/0001-Fix-for-FIPS.patch b/recipe/0001-Fix-for-FIPS.patch
@@ -41,7 +41,7 @@ index 0000000..98f8898
 +2.40.1
 +
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 2ad3847..16ed2fd 100644
+index 2ad3847..edec9f8 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -9,6 +9,8 @@ package:
@@ -53,16 +53,18 @@ index 2ad3847..16ed2fd 100644
  
  build:
    noarch: python
-@@ -28,7 +30,7 @@ requirements:
+@@ -28,16 +30,16 @@ requirements:
      - huggingface_hub >=0.2.0,<1.0.0
      - importlib-metadata
      - multiprocess
 -    - numpy >=1.17
 +    - numpy {{ numpy }}
      - packaging
-     - pandas
+-    - pandas
++    - pandas 2.0
      - pyarrow >=6.0.0
-@@ -37,7 +39,7 @@ requirements:
+     - python >=3.6
+     - python-xxhash
      - pyyaml >=5.1
      - requests >=2.19.0
      - responses <0.19

--- a/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
+++ b/envs/feedstock-patches/sklearn-pandas/0001-sklearn-pandas-recipe.patch
@@ -1,14 +1,14 @@
-From 072cce4ac3da7be3a419e9ebe9abc616727f0be8 Mon Sep 17 00:00:00 2001
-From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Thu, 23 Mar 2023 08:57:35 +0000
+From d6ce8d8224ba6a4cf84697070403d7a4a1161605 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Tue, 17 Oct 2023 10:28:47 +0000
 Subject: [PATCH] Sklearn pandas recipe
 
 ---
- recipe/meta.yaml | 10 +++++-----
- 1 file changed, 5 insertions(+), 5 deletions(-)
+ recipe/meta.yaml | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index fc916e2..ada09f2 100644
+index fc916e2..2276e92 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -18,13 +18,13 @@ build:
@@ -21,15 +21,16 @@ index fc916e2..ada09f2 100644
 -    - python >=3.7
 -    - scikit-learn >=0.23.0
 -    - scipy >=1.5.1
+-    - pandas >=1.1.4
+-    - numpy >=1.18.1
 +    - python
 +    - scikit-learn {{ scikit_learn }}
 +    - scipy {{ scipy }}
-     - pandas >=1.1.4
--    - numpy >=1.18.1
++    - pandas 2.0
 +    - numpy {{ numpy }}
  
  test:
    imports:
 -- 
-2.34.1
+2.40.1
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes the following error with sklearn-pandas recipe

```
ImportError: this version of pandas is incompatible with numpy < 1.22.4
your numpy version is 1.22.3.
Please upgrade numpy to >= 1.22.4 to use this pandas version
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
