### PR TITLE
disable tensorflow-serving env

### DIFF
--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -22,7 +22,7 @@ imported_envs:
   - deepspeed-env.yaml                 # [build_type == 'cpu' or cudatoolkit == '11.8']
   - misc-env.yaml
   - or-tools-env.yaml
-  - tensorflow-serving-env.yaml
+#  - tensorflow-serving-env.yaml
   - transformers-env.yaml
 
   # On s390x, ffmpeg is not available in anaconda's main channel, hence we need to use our own ffmpeg for s390x


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Conflict is observed while installing all opence packages together on x86. As an attempt to fix this disabling TF-. serving.yaml 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
