### PR TITLE
Removed boost-cpp, libevent, thrift-cpp from arrow-env for s390x

### DIFF
--- a/envs/arrow-env.yaml
+++ b/envs/arrow-env.yaml
@@ -11,16 +11,6 @@ packages:
     git_tag: 8bfee448e77492920c23780385dddc5982947e58
   - feedstock : https://github.com/AnacondaRecipes/glog-feedstock
     git_tag: b6c2a87be675b6bf46a8b158372610926a74857b
-  - feedstock : https://github.com/AnacondaRecipes/boost-cpp-feedstock
-    git_tag: 95c6649b96a11fb439d04fe36cc645720d156afb
-    patches:
-      - feedstock-patches/boost_cpp/build-only-required.patch
-  - feedstock : https://github.com/AnacondaRecipes/libevent-feedstock
-    git_tag: 2417ee9ec9baafa03fd8d4970e48a70c3e55d249
-    patches:
-      - feedstock-patches/libevent/s390x-fix1.patch
-  - feedstock : https://github.com/AnacondaRecipes/thrift-cpp-feedstock
-    git_tag: 09e3838f8caaa3ab9728b111620422dd524459e1
 {% endif %}
 {% if build_type == 'cuda' %}
   - feedstock : cudatoolkit

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -26,7 +26,7 @@ bsddb3:
   - 6.2.9
 boost:
   - 1.73.0  # [not s390x]
-  - 1.65.*  # [s390x]
+  - 1.82.*  # [s390x]
 boost_mp11:
   - 1.76.*
 c_compiler_version:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
