### PR TITLE
Pinned typing-extensions for ppc

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -317,7 +317,7 @@ tqdm:
 typer:
   - 0.4.0
 typing_extensions:
-  - 4.*
+  - 4.*    #[not ppc64le]
   - 4.7.1  #[ppc64le]  
 unzip:
   - 6.0

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -318,6 +318,7 @@ typer:
   - 0.4.0
 typing_extensions:
   - 4.*
+  - 4.7.1  #[ppc64le]  
 unzip:
   - 6.0
 wasabi:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

_typing-extensions_ depends on _typing_extensions_, but `typing_extensions v4.9.0` is not available on PPC. 


```
$ conda search typing-extensions=4.9.0 --info
Loading channels: done
typing-extensions 4.9.0 pyhd3eb1b0_0
------------------------------------
file name   : typing-extensions-4.9.0-pyhd3eb1b0_0.conda
name        : typing-extensions
version     : 4.9.0
build       : pyhd3eb1b0_0
build number: 0
size        : 9 KB
license     : PSF-2.0
subdir      : noarch
url         : https://repo.anaconda.com/pkgs/main/noarch/typing-extensions-4.9.0-pyhd3eb1b0_0.conda
md5         : 6f72ac1a17beb0c06f1c285b47984c73
timestamp   : 2024-01-11 20:41:16 UTC
dependencies:
  - python
  - typing_extensions 4.9.0 py311h06a4308_0
```

```
$ conda search typing_extensions
Loading channels: done
# Name                       Version           Build  Channel
typing_extensions              3.7.4          py27_0  pkgs/main
typing_extensions              3.7.4          py36_0  pkgs/main
typing_extensions              3.7.4          py37_0  pkgs/main
typing_extensions            3.7.4.1          py27_0  pkgs/main
typing_extensions            3.7.4.1          py36_0  pkgs/main
typing_extensions            3.7.4.1          py37_0  pkgs/main
typing_extensions            3.7.4.1          py38_0  pkgs/main
typing_extensions            3.7.4.2            py_0  pkgs/main
typing_extensions            3.7.4.3            py_0  pkgs/main
typing_extensions            3.7.4.3    pyh06a4308_0  pkgs/main
typing_extensions            3.7.4.3    pyha847dfd_0  pkgs/main
typing_extensions           3.10.0.0    pyh06a4308_0  pkgs/main
typing_extensions           3.10.0.0    pyhca03da5_0  pkgs/main
typing_extensions           3.10.0.2    pyh06a4308_0  pkgs/main
typing_extensions              4.1.1    pyh06a4308_0  pkgs/main
typing_extensions              4.3.0 py310h6ffa863_0  pkgs/main
typing_extensions              4.3.0  py37h6ffa863_0  pkgs/main
typing_extensions              4.3.0  py38h6ffa863_0  pkgs/main
typing_extensions              4.3.0  py39h6ffa863_0  pkgs/main
typing_extensions              4.4.0 py310h6ffa863_0  pkgs/main
typing_extensions              4.4.0 py311h6ffa863_0  pkgs/main
typing_extensions              4.4.0  py37h6ffa863_0  pkgs/main
typing_extensions              4.4.0  py38h6ffa863_0  pkgs/main
typing_extensions              4.4.0  py39h6ffa863_0  pkgs/main
typing_extensions              4.5.0 py310h6ffa863_0  pkgs/main
typing_extensions              4.5.0 py311h6ffa863_0  pkgs/main
typing_extensions              4.5.0  py38h6ffa863_0  pkgs/main
typing_extensions              4.5.0  py39h6ffa863_0  pkgs/main
typing_extensions              4.6.3 py310h6ffa863_0  pkgs/main
typing_extensions              4.6.3 py311h6ffa863_0  pkgs/main
typing_extensions              4.6.3  py38h6ffa863_0  pkgs/main
typing_extensions              4.6.3  py39h6ffa863_0  pkgs/main
typing_extensions              4.7.1 py310h6ffa863_0  pkgs/main
typing_extensions              4.7.1 py311h6ffa863_0  pkgs/main
typing_extensions              4.7.1  py38h6ffa863_0  pkgs/main
typing_extensions              4.7.1  py39h6ffa863_0  pkgs/main
```
Hence pinning `typing-extensions` to 4.7.1 for PPC. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
