### PR TITLE
Revert "update patch for uwsgi to use python 3.11.5 or higher for py311 (#1147)"

### DIFF
--- a/envs/feedstock-patches/uwsgi/0001-Opence-changes.patch
+++ b/envs/feedstock-patches/uwsgi/0001-Opence-changes.patch
@@ -1,15 +1,14 @@
-From a1e5a39f9cfebda3d5f053280b89d61ee323cdc1 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Thu, 16 May 2024 10:27:52 +0000
+From cc7ecccdec3305aa6c39a9601a34ac47fc4928c9 Mon Sep 17 00:00:00 2001
+From: Aman Surkar <Aman.Surkar@ibm.com>
+Date: Fri, 3 May 2024 11:41:30 +0000
 Subject: [PATCH] Opence-changes
 
-update
 ---
- recipe/meta.yaml | 15 ++++++++-------
- 1 file changed, 8 insertions(+), 7 deletions(-)
+ recipe/meta.yaml | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 31f6612..c025f9a 100644
+index 31f6612..8ef8076 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -1,5 +1,5 @@
@@ -37,15 +36,14 @@ index 31f6612..c025f9a 100644
      - cross-python_{{ target_platform }}     # [build_platform != target_platform]
    host:
      - icu
-@@ -27,13 +27,14 @@ requirements:
+@@ -27,13 +27,13 @@ requirements:
      - libxml2  # [not win]
      - openssl
      - pcre
 -    - pip
 -    - python
 +    - pip {{pip}}
-+    - python >=3.11.5,<3.12  #[py==311]
-+    - python {{python}} #[py==310]
++    - python {{python}}
      - yaml
 -    - zlib
 +    - zlib {{zlib}}


### PR DESCRIPTION
…hon=3.11 (#1147)"

This reverts commit 93c8629e2ceceb91c0b4d8156dd188b5c48d5a0d.

## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

libpython-static v3.11.5 is not available for python 3.11.5 and openssl 3. Hence reverting this commit. 


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
