### PR TITLE
[1.11.1] Fix langchain-core CVE-2024-28088 CVE-2024-1455 and orjson CVE-2024-27454

### DIFF
--- a/envs/feedstock-patches/langchain-community/0001-changes-for-opence.patch
+++ b/envs/feedstock-patches/langchain-community/0001-changes-for-opence.patch
@@ -1,20 +1,20 @@
-From 304793efec9eb6f964fbf0c71f85b2da77dafb93 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Mon, 11 Mar 2024 08:40:03 +0000
-Subject: [PATCH] changes for opence
+From e9bdd73e27737aebccd997dda8b1aed9f0c6a0bb Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <Archana.Shinde1@ibm.com>
+Date: Fri, 31 May 2024 05:55:32 +0000
+Subject: [PATCH] open-ce channges
 
 ---
  recipe/meta.yaml | 66 ------------------------------------------------
  1 file changed, 66 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index ed6e52e..6302529 100644
+index d896066..08e2cdf 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -30,72 +30,6 @@ requirements:
      - tenacity >=8.1.0,<9.0.0
      - dataclasses-json >=0.5.7,<0.7
-     - langsmith >=0.0.83,<0.1
+     - langsmith >=0.1.0,<0.2.0
 -  run_constrained:
 -    - tqdm >=4.48.0
 -    - openapi-pydantic >=0.3.2,<0.4.0

--- a/envs/feedstock-patches/langchain/0001-Opence-changes-for-langchain.patch
+++ b/envs/feedstock-patches/langchain/0001-Opence-changes-for-langchain.patch
@@ -1,17 +1,17 @@
-From 2b0b943ead07da33173a59d208b1ff3f3fa5a85f Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Tue, 12 Mar 2024 14:48:51 +0000
-Subject: [PATCH] Opence changes for langchain
+From aba70691e61749d8b34b1a8864ddd40d0b739b29 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <Archana.Shinde1@ibm.com>
+Date: Fri, 31 May 2024 05:50:00 +0000
+Subject: [PATCH] opence changes
 
 ---
  recipe/meta.yaml | 101 ++++-------------------------------------------
  1 file changed, 7 insertions(+), 94 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 1739753..d656faf 100644
+index 0e33bf0..a931131 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
-@@ -13,116 +13,29 @@ build:
+@@ -13,117 +13,30 @@ build:
    entry_points:
      - langchain-server = langchain.server:main
    noarch: python
@@ -25,12 +25,13 @@ index 1739753..d656faf 100644
 +    - python
      - poetry-core >=1.0.0
 -    - pip
-+    - pip {{pip}}
++    - pip {{ pip }}
    run:
+     - langchain-text-splitters >=0.0.1,<0.1
 -    - python >=3.8,<4.0
 +    - python
-     - langchain-core >=0.1.22,<0.2
-     - langchain-community >=0.0.18,<0.1
+     - langchain-core >=0.1.33,<0.2.0
+     - langchain-community >=0.0.29,<0.1
 -    - pydantic >=1,<3
 +    - pydantic {{pydantic}}
      - sqlalchemy >=1.4,<3
@@ -44,7 +45,7 @@ index 1739753..d656faf 100644
      - jsonpatch >=1.33.0,<2.0.0
      - dataclasses-json >=0.5.7,<0.7
      - async-timeout >=4.0.0,<5.0.0
-     - langsmith >=0.0.83,<0.1
+     - langsmith >=0.1.17,<0.2.0
 -  run_constrained:
 -    - azure-core >=1.26.4,<2.0.0
 -    - tqdm >=4.48.0

--- a/envs/feedstock-patches/langchain/0001-opence-changes-for-langchain-core.patch
+++ b/envs/feedstock-patches/langchain/0001-opence-changes-for-langchain-core.patch
@@ -1,0 +1,40 @@
+From 2a09e5be87a1f1cb1419c8fbfaefe32ab87adbc4 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <Archana.Shinde1@ibm.com>
+Date: Fri, 31 May 2024 09:37:02 +0000
+Subject: [PATCH] opence changes for langchain-core
+
+---
+ recipe/meta.yaml | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 1f5ec41..500d1f8 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -16,18 +16,18 @@ build:
+ 
+ requirements:
+   host:
+-    - python >=3.8,<4.0
++    - python
+     - poetry-core >=1.0.0
+-    - pip
++    - pip {{pip}}
+   run:
+-    - python >=3.8.1,<4.0
+-    - pydantic >=1,<3
++    - python
++    - pydantic {{pydantic}}
+     - langsmith >=0.1.0,<0.2.0
+     - tenacity >=8.1.0,<9.0.0
+     - jsonpatch >=1.33.0,<2.0.0
+     - anyio >=3,<5
+     - pyyaml >=5.3
+-    - requests >=2.0.0,<3.0.0
++    - requests {{requests}}
+     - packaging >=23.2.0,<24.0.0
+   run_constrained:
+     - jinja2 >=3.0.0,<4.0.0
+-- 
+2.40.1
+

--- a/envs/feedstock-patches/langchain/0001-opence-changes-for-langchain-text-splitters.patch
+++ b/envs/feedstock-patches/langchain/0001-opence-changes-for-langchain-text-splitters.patch
@@ -1,0 +1,31 @@
+From b3672e41aa3c38969da669936b54ab97be33b346 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <Archana.Shinde1@ibm.com>
+Date: Fri, 31 May 2024 09:35:16 +0000
+Subject: [PATCH] opence changes for langchain-text-splitters
+
+---
+ recipe/meta.yaml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 784ea35..ab47e98 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -16,11 +16,11 @@ build:
+ 
+ requirements:
+   host:
+-    - python >=3.8,<4.0
++    - python
+     - poetry-core >=1.0.0
+-    - pip
++    - pip {{pip}}
+   run:
+-    - python >=3.8.1,<4.0
++    - python
+     - langchain-core >=0.1.28,<0.2.0
+   run_constrained:
+     - lxml >=5.1.0,<6.0.0
+-- 
+2.40.1
+

--- a/envs/feedstock-patches/langchain/0001-opence-changes-for-langsmith.patch
+++ b/envs/feedstock-patches/langchain/0001-opence-changes-for-langsmith.patch
@@ -1,0 +1,35 @@
+From 46be4a0478f89008d55ab27699f02a1ffa9b3a2b Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <Archana.Shinde1@ibm.com>
+Date: Fri, 31 May 2024 09:33:45 +0000
+Subject: [PATCH] opence changes
+
+---
+ recipe/meta.yaml | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 25605bc..0739aee 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -18,13 +18,13 @@ build:
+ 
+ requirements:
+   host:
+-    - python >=3.8.1,<4.0
++    - python
+     - poetry-core
+-    - pip
++    - pip {{pip}}
+   run:
+-    - python >=3.8.1,<4.0
+-    - pydantic >=1,<3
+-    - requests >=2.0.0,<3.0.0
++    - python
++    - pydantic {{pydantic}}
++    - requests {{requests}}
+     - orjson >=3.9.14,<4.0.0
+ 
+ test:
+-- 
+2.40.1
+

--- a/envs/langchain-env.yaml
+++ b/envs/langchain-env.yaml
@@ -16,7 +16,7 @@ packages:
   - feedstock : https://github.com/AnacondaRecipes/orjson-feedstock                #[ppc64le]
     git_tag : bdea9ad2212ca9185bb81928a3b7ba4c5c59cbaf                             #[ppc64le]          
   - feedstock : https://github.com/conda-forge/langchain-text-splitters-feedstock.git
-    git_tag : 58421cd09fa7a223738594cab7b1158d8b21e31f
+    git_tag : b1a882d80228a52e0efd0d78985e403bfcdf58bb
     patches :
       - feedstock-patches/langchain/0001-opence-changes-for-langchain-text-splitters.patch
   - feedstock : https://github.com/conda-forge/langsmith-feedstock.git

--- a/envs/langchain-env.yaml
+++ b/envs/langchain-env.yaml
@@ -13,18 +13,26 @@ packages:
     git_tag : e04488e01c5686c08fbe433ac838c12113e6b5b2                             #[ppc64le]
   - feedstock : https://github.com/conda-forge/jsonpatch-feedstock.git             #[ppc64le]
     git_tag : b91d2f21f2e8cf6cf2af15ab8e36e753a340ff55                             #[ppc64le]
+  - feedstock : https://github.com/AnacondaRecipes/orjson-feedstock                #[ppc64le]
+    git_tag : bdea9ad2212ca9185bb81928a3b7ba4c5c59cbaf                             #[ppc64le]          
+  - feedstock : https://github.com/conda-forge/langchain-text-splitters-feedstock.git
+    git_tag : 58421cd09fa7a223738594cab7b1158d8b21e31f
+    patches :
+      - feedstock-patches/langchain/0001-opence-changes-for-langchain-text-splitters.patch
   - feedstock : https://github.com/conda-forge/langsmith-feedstock.git
-    git_tag : 010eb770882b877d27c5dde1fe6ed66db56d284a
+    git_tag : aabd64e30fe4e5efb49bc44b254d8b7586717d99
     patches :
-           - feedstock-patches/langchain/0001-Removed-pytest-subtests.patch
+      - feedstock-patches/langchain/0001-opence-changes-for-langsmith.patch 
   - feedstock : https://github.com/conda-forge/langchain-community-feedstock.git
-    git_tag : 6ec329ff0dbae6943c5ccfba0163ebb17903bc19
+    git_tag : 85e26900b84c2b3b96c89060e602ed6b6e7d4c37
     patches :
-           - feedstock-patches/langchain-community/0001-changes-for-opence.patch
+      - feedstock-patches/langchain-community/0001-changes-for-opence.patch
   - feedstock : https://github.com/conda-forge/langchain-core-feedstock.git
-    git_tag : 11e865add3303da3f3ffae317dd6c75443d481bb
-  - feedstock : https://github.com/conda-forge/langchain-feedstock.git
-    git_tag : 6431d8c54b8a22424fcb639590691802469c375f
+    git_tag : dd3be8796e9c91d7bd4e454d33f326605743bb13
     patches :
-           - feedstock-patches/langchain/0001-Opence-changes-for-langchain.patch
+      - feedstock-patches/langchain/0001-opence-changes-for-langchain-core.patch
+  - feedstock : https://github.com/conda-forge/langchain-feedstock.git
+    git_tag : a73cf20cb696f83f9debb53fa46eed2565b1e360
+    patches :
+      - feedstock-patches/langchain/0001-Opence-changes-for-langchain.patch 
 git_tag_for_env: open-ce-v1.11.0

--- a/envs/langchain-env.yaml
+++ b/envs/langchain-env.yaml
@@ -13,8 +13,8 @@ packages:
     git_tag : e04488e01c5686c08fbe433ac838c12113e6b5b2                             #[ppc64le]
   - feedstock : https://github.com/conda-forge/jsonpatch-feedstock.git             #[ppc64le]
     git_tag : b91d2f21f2e8cf6cf2af15ab8e36e753a340ff55                             #[ppc64le]
-  - feedstock : https://github.com/AnacondaRecipes/orjson-feedstock                #[ppc64le]
-    git_tag : bdea9ad2212ca9185bb81928a3b7ba4c5c59cbaf                             #[ppc64le]          
+  - feedstock : https://github.com/AnacondaRecipes/orjson-feedstock                #[not x86_64]
+    git_tag : bdea9ad2212ca9185bb81928a3b7ba4c5c59cbaf                             #[not x86_64]
   - feedstock : https://github.com/conda-forge/langchain-text-splitters-feedstock.git
     git_tag : b1a882d80228a52e0efd0d78985e403bfcdf58bb
     patches :

--- a/envs/opence-env.yaml
+++ b/envs/opence-env.yaml
@@ -26,6 +26,7 @@ imported_envs:
   - transformers-env.yaml
   - ffmpeg-env.yaml
   - langchain-env.yaml
+  - tensorboard-env.yaml
 
 packages:
   - feedstock : https://github.com/conda-forge/joblib-feedstock

--- a/envs/transformers-env.yaml
+++ b/envs/transformers-env.yaml
@@ -17,6 +17,8 @@ packages:
     git_tag : 8bdaa6419a2aa2b336076a4a3d714244afb6cc88
     patches :
       - feedstock-patches/tokenizers/0001-opence-changes.patch
+  - feedstock : https://github.com/conda-forge/safetensors-feedstock     #[not x86_64]
+    git_tag : 1e5227b14f1c93caa9819f429e15b859cee36236                   #[not x86_64]
   - feedstock : https://github.com/conda-forge/transformers-feedstock
     git_tag : 053ca66df0d4963ad295b5e2f9f0d0a2f42c51b1
   - feedstock : https://github.com/conda-forge/huggingface_hub-feedstock


### PR DESCRIPTION
Fix langchain-core CVE on ppc by updating patches of langchain dependancies
langchain has dependancy on orjson, so build on ppc  
 


