### PR TITLE
set env path to use gcc-13 to fix p10 build 

### DIFF
--- a/envs/feedstock-patches/llama.cpp/0001-Update-v0.0.5038-to-allow-MMA-for-FP32-INT8-and-INT4.patch
+++ b/envs/feedstock-patches/llama.cpp/0001-Update-v0.0.5038-to-allow-MMA-for-FP32-INT8-and-INT4.patch
@@ -1,12 +1,12 @@
-From edb32dcf2ef664f45b62b588153601cc3b37527a Mon Sep 17 00:00:00 2001
+From e68401fa250910cd04c75113d31490436a0cd9b9 Mon Sep 17 00:00:00 2001
 From: Archana-Shinde1 <archana.shinde1@ibm.com>
-Date: Wed, 23 Apr 2025 12:52:31 +0000
-Subject: [PATCH] add change to use gcc-13 for p10 build
+Date: Thu, 24 Apr 2025 14:03:41 +0000
+Subject: [PATCH] set env path to use gcc-13
 
 ---
  recipe/conda_build_config.yaml |  3 ++
- recipe/meta.yaml               | 55 ++++++++++++++++------------------
- 2 files changed, 28 insertions(+), 30 deletions(-)
+ recipe/meta.yaml               | 56 ++++++++++++++++------------------
+ 2 files changed, 29 insertions(+), 30 deletions(-)
 
 diff --git a/recipe/conda_build_config.yaml b/recipe/conda_build_config.yaml
 index 7071b8b..0923543 100644
@@ -20,7 +20,7 @@ index 7071b8b..0923543 100644
 +cuda_compiler:
 +  - nvcc
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index b1428da..d1fd233 100644
+index b1428da..cec3c56 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -1,5 +1,5 @@
@@ -30,7 +30,7 @@ index b1428da..d1fd233 100644
  
  package:
    name: {{ name|lower }}
-@@ -7,15 +7,12 @@ package:
+@@ -7,17 +7,15 @@ package:
  
  source:
    url: https://github.com/ggerganov/llama.cpp/archive/b{{ version.split(".")[-1] }}.tar.gz
@@ -48,8 +48,11 @@ index b1428da..d1fd233 100644
 +  string: cpu_py{{ python | replace(".", "") }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  #[build_type == 'cpu']
  
    script:
++    - export PATH=$GCC_13_HOME/bin:$PATH                #[ppc_arch == 'p10']
      - LLAMA_ARGS="-DLLAMA_BUILD_TESTS=OFF"              # [unix]
-@@ -40,11 +37,13 @@ build:
+     - set LLAMA_ARGS=-DLLAMA_BUILD_TESTS=OFF            # [win]
+     {% macro llama_args(value) -%}
+@@ -40,11 +38,13 @@ build:
      {{ llama_args("METAL=OFF") }}       # [osx and x86_64]
      {{ llama_args("ACCELERATE=ON") }}   # [osx]
  
@@ -67,7 +70,7 @@ index b1428da..d1fd233 100644
  
      - echo $LLAMA_ARGS  # [unix]
      - set LLAMA_ARGS    # [win]
-@@ -53,6 +52,9 @@ build:
+@@ -53,6 +53,9 @@ build:
      - cmake -S . -B build -G Ninja ${CMAKE_ARGS} ${LLAMA_ARGS}  # [unix]
      - cmake --build build
      - cmake --install build 
@@ -77,7 +80,7 @@ index b1428da..d1fd233 100644
    
    missing_dso_whitelist:
      - "*/nvcuda.dll"    # [win]
-@@ -60,35 +62,28 @@ build:
+@@ -60,35 +63,28 @@ build:
  
  requirements:
    build:


### PR DESCRIPTION
llama.cpp build failed to pick up the env path var GCC-13 on the p10 build, so fixed it by adding 'export PATH=$GCC_13_HOME/bin:$PATH'