### PR TITLE
Make libarchive use libxml2 2.13.8 to fix CVE on PPC

### DIFF
--- a/envs/feedstock-patches/libarchive/0001-Opence-changes.patch
+++ b/envs/feedstock-patches/libarchive/0001-Opence-changes.patch
@@ -1,0 +1,54 @@
+From f320cfee68e3312c92fe0a36cbcec61c41588f66 Mon Sep 17 00:00:00 2001
+From: Aman Surkar <Aman.Surkar@ibm.com>
+Date: Thu, 21 Aug 2025 18:20:18 +0000
+Subject: [PATCH] Opence changes
+
+---
+ recipe/meta.yaml | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 0ed1e0e..9979cbc 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -21,15 +21,15 @@ build:
+ 
+ requirements:
+   build:
+-    - {{ stdlib('c') }}
++#    - {{ stdlib('c') }}
+     - {{ compiler('c') }}
+     - cmake
+     - ninja-base
+   host:
+-    - bzip2 {{ bzip2 }}
++    - bzip2
+     - libiconv {{ libiconv }}  # [not linux]
+-    - lz4-c {{ lz4_c }}
+-    - xz {{ xz }}
++    - lz4-c
++    - xz
+     # This is GPL-v2+, the libarchive authors explicitly ask that
+     # people do not link to this (and if we do, this would need to
+     # also be released as GPL-v2+, and that is against their wishes
+@@ -39,8 +39,8 @@ requirements:
+     #  Please don't distribute binary packages of libarchive linked
+     #  against liblzo."
+     # - lzo
+-    - openssl {{ openssl }} # [not osx]
+-    - libxml2 {{ libxml2 }}
++    - openssl
++    - libxml2
+     - zlib {{ zlib }}
+     - zstd {{ zstd }}
+   run:
+@@ -95,4 +95,4 @@ extra:
+   recipe-maintainers:
+     - jakirkham
+     - mingwandroid
+-    - ocefpaf
+\ No newline at end of file
++    - ocefpaf
+-- 
+2.40.1
+

--- a/envs/feedstock-patches/libxml2/0001-Opence-changes.patch
+++ b/envs/feedstock-patches/libxml2/0001-Opence-changes.patch
@@ -1,0 +1,25 @@
+From b0f19576e2250efff2e3bd9cfbbb29da14b833fb Mon Sep 17 00:00:00 2001
+From: Aman Surkar <Aman.Surkar@ibm.com>
+Date: Thu, 21 Aug 2025 17:52:22 +0000
+Subject: [PATCH] Opence changes
+
+---
+ recipe/meta.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 03b3c8d..c7e7743 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -29,7 +29,7 @@ requirements:
+   host:
+     - icu {{icu}}     # [not win]
+     - libiconv 1.16   # [not linux]
+-    - xz {{xz}}       # [not win]
++    - xz       # [not win]
+     - zlib {{zlib}}
+   run:
+     - libiconv  # [not linux]
+-- 
+2.40.1
+

--- a/envs/mamba-env.yaml
+++ b/envs/mamba-env.yaml
@@ -8,12 +8,12 @@ packages:
     git_tag : e2c3753d98b05d93dfb4561a4da2b65fc531a3ca
     patches:
       - feedstock-patches/zlib/0001-Fixed-CVEs-for-zlib.patch
-  - feedstock : https://github.com/AnacondaRecipes/libarchive-feedstock #[ppc64le]
-    git_tag : f700e747b17f4b2a649a9157110e8acd9f72c443                  #[ppc64le]
-    patches:                                                            #[ppc64le]
-      - feedstock-patches/libarchive/0001-Opence-changes.patch          #[ppc64le]
-  - feedstock : https://github.com/AnacondaRecipes/libxml2-feedstock    #[ppc64le]
-    git_tag : e535e8edb4811bd9825e5749065c13458d6f7dce                  #[ppc64le]
-    patches:                                                            #[ppc64le]
-      - feedstock-patches/libxml2/0001-Opence-changes.patch             #[ppc64le]
+  - feedstock : https://github.com/AnacondaRecipes/libarchive-feedstock #[not x86_64]
+    git_tag : f700e747b17f4b2a649a9157110e8acd9f72c443                  #[not x86_64]
+    patches:                                                            #[not x86_64]
+      - feedstock-patches/libarchive/0001-Opence-changes.patch          #[not x86_64]
+  - feedstock : https://github.com/AnacondaRecipes/libxml2-feedstock    #[not x86_64]
+    git_tag : e535e8edb4811bd9825e5749065c13458d6f7dce                  #[not x86_64]
+    patches:                                                            #[not x86_64]
+      - feedstock-patches/libxml2/0001-Opence-changes.patch             #[not x86_64]
 git_tag_for_env: open-ce-v1.11.6

--- a/envs/mamba-env.yaml
+++ b/envs/mamba-env.yaml
@@ -8,4 +8,12 @@ packages:
     git_tag : e2c3753d98b05d93dfb4561a4da2b65fc531a3ca
     patches:
       - feedstock-patches/zlib/0001-Fixed-CVEs-for-zlib.patch
+  - feedstock : https://github.com/AnacondaRecipes/libarchive-feedstock #[ppc64le]
+    git_tag : f700e747b17f4b2a649a9157110e8acd9f72c443                  #[ppc64le]
+    patches:                                                            #[ppc64le]
+      - feedstock-patches/libarchive/0001-Opence-changes.patch          #[ppc64le]
+  - feedstock : https://github.com/AnacondaRecipes/libxml2-feedstock    #[ppc64le]
+    git_tag : e535e8edb4811bd9825e5749065c13458d6f7dce                  #[ppc64le]
+    patches:                                                            #[ppc64le]
+      - feedstock-patches/libxml2/0001-Opence-changes.patch             #[ppc64le]
 git_tag_for_env: open-ce-v1.11.6


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
