### PR TITLE
Reverted back pin of bazel to 6.1

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -19,7 +19,7 @@ automake:
 av:
   - 10.*
 bazel:
-  - 6.5.*
+  - 6.1.*
 black:
   - 24.8.0
 bsddb3:


### PR DESCRIPTION
Failure observed during TF build, so reverted back to 6.1.*