### PR TITLE
Fix TF build on s390x, alter pin of icu to use v73.*

### DIFF
--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -115,8 +115,8 @@ hypothesis:
 h5py:
   - 3.7.*
 icu:
-  - 58.*   #[not s390x]
-  - 68.*   #[s390x]
+  - 58.*  # [(x86_64 or (ppc_arch == "p10")) and not (s390x)]
+  - 73.*  # [(s390x or (ppc_arch != "p10")) and not x86_64]
 importlib_resources:
   - 5.*
 jasper:

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -115,7 +115,7 @@ hypothesis:
 h5py:
   - 3.7.*
 icu:
-  - 58.*  # [(x86_64 or (ppc_arch == "p10")) and not (s390x)]
+  - 58.*  # [(x86_64 or (ppc_arch == "p10")) and not s390x]
   - 73.*  # [(s390x or (ppc_arch != "p10")) and not x86_64]
 importlib_resources:
   - 5.*


### PR DESCRIPTION
## Description
The TensorFlow build failed because the build environment was using ICU v68.*, while the build_pip_package script explicitly required ICU v73.*. This version mismatch caused missing symbol/function reference errors related to ICU v73.

Fixes # (issue).
To resolve the issue, the ICU pin updated to v73.* to align with the Bazel build configuration.


