### PR TITLE
Make pyarrow compatible with brotli 1.2.0 at runtime

### DIFF
--- a/envs/arrow-env.yaml
+++ b/envs/arrow-env.yaml
@@ -12,8 +12,7 @@ packages:
     patches :                                                       #[ppc_arch == 'p10']
       - feedstock-patches/abseil-cpp/0001-P10-changes.patch         #[ppc_arch == 'p10']
   - feedstock : grpc-cpp
-  - feedstock : https://github.com/smartvibs8876/pyarrow-feedstock
-    git_tag : build-with-brotli-120
+  - feedstock : pyarrow
   - feedstock : orc
   - feedstock : https://github.com/conda-forge/brotli-feedstock.git
     git_tag : 61563a5a99db058833a6397855bcafd36ff97905

--- a/envs/arrow-env.yaml
+++ b/envs/arrow-env.yaml
@@ -12,7 +12,8 @@ packages:
     patches :                                                       #[ppc_arch == 'p10']
       - feedstock-patches/abseil-cpp/0001-P10-changes.patch         #[ppc_arch == 'p10']
   - feedstock : grpc-cpp
-  - feedstock : pyarrow
+  - feedstock : https://github.com/smartvibs8876/pyarrow-feedstock
+    git_tag : build-with-brotli-120
   - feedstock : orc
   - feedstock : https://github.com/conda-forge/brotli-feedstock.git
     git_tag : 61563a5a99db058833a6397855bcafd36ff97905

--- a/envs/arrow-env.yaml
+++ b/envs/arrow-env.yaml
@@ -14,4 +14,8 @@ packages:
   - feedstock : grpc-cpp
   - feedstock : pyarrow
   - feedstock : orc
+  - feedstock : https://github.com/conda-forge/brotli-feedstock.git
+    git_tag : 61563a5a99db058833a6397855bcafd36ff97905
+    patches :
+      - feedstock-patches/brotli/0001-Removed-stdlibc.patch
 git_tag_for_env: open-ce-v1.11.7-p9

--- a/envs/conda_build_config.yaml
+++ b/envs/conda_build_config.yaml
@@ -29,6 +29,8 @@ boost:
   - 1.82.*  # [s390x]
 boost_mp11:
   - 1.76.*
+brotli:
+  - 1.2.0
 c_compiler_version:
   - 11.2.*
 catalogue:

--- a/envs/feedstock-patches/brotli/0001-Removed-stdlibc.patch
+++ b/envs/feedstock-patches/brotli/0001-Removed-stdlibc.patch
@@ -1,0 +1,79 @@
+From 88c687b212b836d33298c10503972b4015010861 Mon Sep 17 00:00:00 2001
+From: Vibhav Dhaimode <Vibhav.Dhaimode2@ibm.com>
+Date: Thu, 4 Dec 2025 05:06:12 +0000
+Subject: [PATCH] Removed stdlib c as we have not set in conda build config
+
+---
+ recipe/meta.yaml | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/recipe/meta.yaml b/recipe/meta.yaml
+index 9360eee..9bcd1e4 100644
+--- a/recipe/meta.yaml
++++ b/recipe/meta.yaml
+@@ -21,7 +21,7 @@ requirements:
+   build:
+     - cmake
+     - {{ compiler('c') }}
+-    - {{ stdlib("c") }}
++    #- {{ stdlib("c") }}
+     - {{ compiler('cxx') }}
+     - ninja
+   host:
+@@ -38,7 +38,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - ninja
+     test:
+       commands:
+@@ -58,7 +58,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - ninja
+       host:
+         - {{ pin_subpackage("libbrotlicommon", exact=True) }}
+@@ -82,7 +82,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - ninja
+       host:
+         - {{ pin_subpackage("libbrotlicommon", exact=True) }}
+@@ -103,7 +103,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - ninja
+       host:
+         - {{ pin_subpackage("libbrotlienc", exact=True) }}
+@@ -126,7 +126,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - ninja
+       host:
+         - {{ pin_subpackage("libbrotlienc", exact=True) }}
+@@ -170,7 +170,7 @@ outputs:
+       build:
+         - cmake
+         - {{ compiler('c') }}
+-        - {{ stdlib("c") }}
++        #- {{ stdlib("c") }}
+         - {{ compiler('cxx') }}
+         - python                                 # [build_platform != target_platform]
+         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+--
+2.40.1
+


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
Pyarrow should use brotli 1.2.0 at runtime. 

Fixes # (issue).
To fix this, pyarrow was built using brotli 1.2.0 and runtime pin of brotli 1.2.0 was added

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
