### PR TITLE
Fixed cmake aioredis and hatch-fancy build failure

### DIFF
--- a/envs/feedstock-patches/aioredis/0001-fix-for-python-3.11.patch
+++ b/envs/feedstock-patches/aioredis/0001-fix-for-python-3.11.patch
@@ -1,12 +1,12 @@
-From 038208fcfb119628199dcb24967f3ce2588d2381 Mon Sep 17 00:00:00 2001
-From: Deepali Chourasia <deepch23@in.ibm.com>
-Date: Thu, 6 Jul 2023 11:13:07 +0000
-Subject: [PATCH] fix build for python 3.11
+From 5377cbf7028f80cb7f8723b65e43ae55d8e76d62 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <archana.shinde1@ibm.com>
+Date: Tue, 30 Dec 2025 12:06:13 +0000
+Subject: [PATCH] Fix test failure
 
 ---
  ...duplicate-class-error-for-python3.11.patch | 31 +++++++++++++++++++
- recipe/meta.yaml                              |  2 ++
- 2 files changed, 33 insertions(+)
+ recipe/meta.yaml                              |  3 ++
+ 2 files changed, 34 insertions(+)
  create mode 100644 recipe/0001-fix-duplicate-class-error-for-python3.11.patch
 
 diff --git a/recipe/0001-fix-duplicate-class-error-for-python3.11.patch b/recipe/0001-fix-duplicate-class-error-for-python3.11.patch
@@ -47,7 +47,7 @@ index 0000000..00f03f1
 +2.34.1
 +
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 451f045..722f753 100644
+index 451f045..0e27b57 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -8,6 +8,8 @@ package:
@@ -59,6 +59,14 @@ index 451f045..722f753 100644
  
  build:
    number: 0
+@@ -28,6 +30,7 @@ test:
+     - aioredis
+   requires:
+     - pip
++    - setuptools
+   commands:
+     - pip check
+ 
 -- 
-2.34.1
+2.40.1
 

--- a/envs/feedstock-patches/cmake/0001-Fixed-invalid-conversion-from-long-int-to-CURL_NETRC.patch
+++ b/envs/feedstock-patches/cmake/0001-Fixed-invalid-conversion-from-long-int-to-CURL_NETRC.patch
@@ -1,13 +1,12 @@
-From bc85719ab8fe74d100378a61a506dd0d81c96ef9 Mon Sep 17 00:00:00 2001
-From: Aman Surkar <Aman.Surkar@ibm.com>
-Date: Fri, 8 Aug 2025 08:37:30 +0000
-Subject: [PATCH] Fixed invalid conversion from 'long int' to
- 'CURL_NETRC_OPTION'
+From add1bd70aeff678c91c8fc8e61b7ea7ade613c02 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <archana.shinde1@ibm.com>
+Date: Tue, 30 Dec 2025 12:20:46 +0000
+Subject: [PATCH] Fix CMake build failure by pinning libcurl <8
 
 ---
  ...on-from-long-int-to-CURL_NETRC_OPTIO.patch | 25 +++++++++++++++++++
- recipe/meta.yaml                              |  2 ++
- 2 files changed, 27 insertions(+)
+ recipe/meta.yaml                              |  6 +++--
+ 2 files changed, 29 insertions(+), 2 deletions(-)
  create mode 100644 recipe/0001-Fix-for-conversion-from-long-int-to-CURL_NETRC_OPTIO.patch
 
 diff --git a/recipe/0001-Fix-for-conversion-from-long-int-to-CURL_NETRC_OPTIO.patch b/recipe/0001-Fix-for-conversion-from-long-int-to-CURL_NETRC_OPTIO.patch
@@ -42,7 +41,7 @@ index 0000000..09a6d58
 +2.40.1
 +
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index 2791fb9..4917f13 100644
+index 2791fb9..d9798a9 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -7,6 +7,8 @@ package:
@@ -54,6 +53,24 @@ index 2791fb9..4917f13 100644
    # Not until Python 3.8 on Windows: https://github.com/WorksApplications/SudachiPy/issues/107#issuecomment-564510365
    # path: 'C:/opt/Shared.local/src/cmake'
    # path_via_symlink: True
+@@ -33,7 +35,7 @@ requirements:
+ 
+   host:
+     - bzip2           # [unix]
+-    - libcurl         # [unix]
++    - libcurl <8        # [unix]
+     - expat           # [unix]
+     - ncurses         # [unix]
+     - xz              # [unix]
+@@ -44,7 +46,7 @@ requirements:
+ 
+   run:
+     - bzip2           # [unix]
+-    - libcurl         # [unix]
++    - libcurl <8        # [unix]
+     - expat           # [unix]
+     - ncurses         # [unix]
+     - xz              # [unix]
 -- 
 2.40.1
 

--- a/envs/feedstock-patches/hatch-fancy-pypi-readme/0001-Upadtes-with-open-ce.patch
+++ b/envs/feedstock-patches/hatch-fancy-pypi-readme/0001-Upadtes-with-open-ce.patch
@@ -1,14 +1,14 @@
-From c9f9491af6250d955c62045df0180e58357d4fa1 Mon Sep 17 00:00:00 2001
-From: ArchanaShinde1 <archana.shinde2504@gmail.com>
-Date: Thu, 14 Dec 2023 04:49:02 +0000
-Subject: [PATCH] Upadtes with open-ce
+From 668ac615e3c8e49a521945a42fcfae75e6b60a22 Mon Sep 17 00:00:00 2001
+From: Archana-Shinde1 <archana.shinde1@ibm.com>
+Date: Tue, 30 Dec 2025 12:25:17 +0000
+Subject: [PATCH] Fix test failure
 
 ---
- recipe/meta.yaml | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ recipe/meta.yaml | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/recipe/meta.yaml b/recipe/meta.yaml
-index af8e81a..c3c0d23 100644
+index af8e81a..bbffde0 100644
 --- a/recipe/meta.yaml
 +++ b/recipe/meta.yaml
 @@ -19,13 +19,13 @@ build:
@@ -27,6 +27,14 @@ index af8e81a..c3c0d23 100644
  
  test:
    source_files:
+@@ -46,6 +46,7 @@ test:
+     - python-build
+     - pip
+     - pytest
++    - wheel
+ 
+ about:
+   home: https://github.com/hynek/hatch-fancy-pypi-readme
 -- 
 2.40.1
 


### PR DESCRIPTION
Fix test failures and CMake build issues

- Resolve aioredis distutils import error
- Add missing wheel dependency for tests
- Pin libcurl <8 to fix curl_proxytype build failure
```
packages/aioredis/connection.py", line 11, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils' 
```
`FAILED tests/test_end_to_end.py::test_build - Failed: $PREFIX/bin/python: No module named wheel `

```
/opt/conda/conda-bld/cmake_1766596480940/work/Source/CTest/cmCTestCurl.cxx:244:25: error: invalid conversion from 'long int' to 'curl_proxytype' [-fpermissive]
make[2]: *** 
```